### PR TITLE
docs: add plugin metadata

### DIFF
--- a/plugins/AGENT.md
+++ b/plugins/AGENT.md
@@ -1,0 +1,9 @@
+# Plugins Metadata
+
+- **Criticality:** 7/10
+- **Purpose:** IDE and editor integrations
+- **Subdirectories:** `vscode/`, `intellij/`, `neovim/`, `sublime/`
+- **Communication:** Each plugin → localhost API
+- **Event types:** File open/save, project switch, language detection
+- **Distribution:** Marketplace/package managers
+

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,16 @@
+# IDE & Editor Plugins
+
+iVibe supports multiple editors and IDEs with dedicated plugins. Install them using your platform's standard extension system.
+
+## VS Code
+Install from the Visual Studio Code Marketplace.
+
+## IntelliJ
+Install via the JetBrains Marketplace.
+
+## Neovim
+Install through your preferred plugin manager (e.g., `packer.nvim`, `vim-plug`).
+
+## Sublime Text
+Install using Package Control.
+


### PR DESCRIPTION
## Summary
- document plugin criticality and communication to localhost
- outline installation methods for VS Code, IntelliJ, Neovim and Sublime plugins

## Testing
- `npm test` *(fails: could not find package.json)*
- `cargo test` *(fails: could not find Cargo.toml)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68947bda3cfc832abc2dec36f4d3720f