### PR TITLE
docs: add android agent and build readme

### DIFF
--- a/mobile/android/AGENT.md
+++ b/mobile/android/AGENT.md
@@ -1,0 +1,9 @@
+# Android Agent Instructions
+
+- **Criticality:** 9/10
+- **Purpose:** Android application
+- **Files:** app/build.gradle.kts, AndroidManifest.xml, MainActivity.kt, IVibeApplication.kt
+- **Services:** TrackerService, LocationService, EmotionService, VibeService
+- **FFI:** Rust integration via JNI for performance
+- **Min SDK:** 24 (Android 7.0)
+- **Permissions:** RECORD_AUDIO, CAMERA, ACCESS_FINE_LOCATION, BLUETOOTH

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -1,0 +1,22 @@
+# iVibe Android App
+
+## Build Instructions
+1. Install Android Studio with the Android SDK and NDK.
+2. Ensure JDK 17 or higher is available.
+3. Clone the repository and open `mobile/android` in Android Studio or run `gradle assembleDebug` from the command line.
+4. Connect a device or start an emulator to run the debug build.
+
+## Signing Process
+1. Generate a release keystore:
+   ```bash
+   keytool -genkey -v -keystore ivibe.keystore -alias ivibe -keyalg RSA -keysize 2048 -validity 10000
+   ```
+2. Store the keystore and passwords outside version control.
+3. Configure the `signingConfigs` block in `app/build.gradle.kts` and reference properties from `gradle.properties` or `local.properties`.
+4. Build the signed release artifact with `gradle assembleRelease` or `gradle bundleRelease`.
+
+## Play Store Deployment
+1. In Google Play Console, create a new application and enable Play App Signing.
+2. Upload the generated `*.aab` bundle from the release build.
+3. Provide required metadata: description, screenshots, content rating, and privacy policy.
+4. Roll out the release to internal, closed, or production tracks as needed.


### PR DESCRIPTION
## Summary
- add Android module agent instructions
- document build, signing, and Play Store steps

## Testing
- `gradle test` *(fails: Task 'test' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947bd2abcc832a8bee8789826c5d42