### PR TITLE
docs: add mobile agent instructions and README

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -1,0 +1,9 @@
+# Mobile Agents Instructions
+
+- **Criticality:** 9/10
+- **Purpose:** Mobile applications
+- **Subdirectories:** `android/` (Kotlin implementation)
+- **Future:** iOS Swift implementation planned
+- **Communication:** HTTPS to API, Bluetooth for Vibe detection
+- **Permissions:** Location, camera, microphone, Bluetooth
+

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,25 @@
+# Mobile
+
+This directory hosts the mobile applications for the iVibe platform. Android is implemented in Kotlin, and an iOS Swift application is planned.
+
+## Architecture
+- Communicates with the iVibe API over HTTPS.
+- Uses Bluetooth to detect nearby Vibes.
+- Current subdirectory: `android/` for the Kotlin implementation.
+
+## Permissions
+The mobile apps require the following permissions:
+- Location for proximity features.
+- Camera for capturing visual context.
+- Microphone for audio-based interactions.
+- Bluetooth for Vibe detection.
+
+## Build Process
+### Android
+1. Install Android Studio and required SDKs.
+2. From the `mobile/android` directory, run `./gradlew assembleDebug` to build a debug APK.
+3. Use `./gradlew installDebug` to deploy the app to a connected device or emulator.
+
+### iOS
+An iOS Swift implementation is planned. Build instructions will be added once development begins.
+


### PR DESCRIPTION
## Summary
- document mobile module criticality, purpose, structure, communications, and permissions
- describe mobile architecture, required permissions, and Android build steps

## Testing
- `cargo test --workspace --manifest-path backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68947b7d14c4832ab24c0c3c6eefd1dd