### PR TITLE
docs(kubernetes): add agent and deployment readme

### DIFF
--- a/infrastructure/kubernetes/AGENT.md
+++ b/infrastructure/kubernetes/AGENT.md
@@ -1,0 +1,10 @@
+# Kubernetes Deployment
+
+- **Criticality**: 8/10
+- **Purpose**: Kubernetes deployment manifests
+- **Subdirectories**:
+  - `helm/ivibe/` – Helm chart
+  - `manifests/` – raw YAML
+- **Resources**: Deployments, Services, ConfigMaps, Secrets
+- **Namespace**: `ivibe`
+- **Scaling**: HPA for auto-scaling based on CPU/memory

--- a/infrastructure/kubernetes/README.md
+++ b/infrastructure/kubernetes/README.md
@@ -1,0 +1,59 @@
+# Kubernetes Deployment Resources
+
+This directory contains deployment configurations for running iVibe on Kubernetes.
+
+## Structure
+
+- `helm/ivibe/` – Helm chart for templated releases.
+- `manifests/` – Raw YAML manifests for direct `kubectl apply` usage.
+
+## Helm Values
+
+The Helm chart exposes configurable values in `values.yaml`.
+Common parameters include:
+
+```yaml
+image:
+  repository: ghcr.io/ivibe/backend
+  tag: latest
+replicaCount: 2
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: ivibe.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Override values during install or upgrade:
+
+```sh
+helm upgrade --install ivibe helm/ivibe -n ivibe -f values.yaml -f values-prod.yaml
+```
+
+## Deployment Strategies
+
+1. **Helm (recommended)** – Manage releases with Helm using the chart in `helm/ivibe`.
+2. **Raw Manifests** – Apply files under `manifests/` directly:
+   ```sh
+   kubectl apply -n ivibe -f manifests/
+   ```
+
+## Production Configuration
+
+- All resources deploy into the `ivibe` namespace.
+- Secrets and configuration are separated via `Secrets` and `ConfigMaps`.
+- Use a `HorizontalPodAutoscaler` for CPU and memory based scaling:
+  ```sh
+  kubectl autoscale deployment ivibe --cpu-percent=70 --min=2 --max=10
+  ```
+- Maintain separate `values-prod.yaml` for production overrides such as persistent storage, domain names, and resource limits.


### PR DESCRIPTION
## Summary
- document kubernetes deployment with AGENT file outlining structure and scaling
- add README covering helm values, deployment strategies and production configuration

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68947b7601cc832abab2fb44c6cd3a72