### PR TITLE
docs: add infrastructure agent and deployment guide

### DIFF
--- a/infrastructure/AGENT.md
+++ b/infrastructure/AGENT.md
@@ -1,0 +1,8 @@
+# Infrastructure Agent
+
+- **Criticality:** 8/10
+- **Purpose:** Deployment and infrastructure configuration
+- **Subdirectories:** `docker/`, `kubernetes/`, `terraform/`, `ansible/`
+- **Deployment targets:** Docker Compose (dev), Kubernetes (prod)
+- **Infrastructure as Code:** Terraform for cloud resources
+- **Configuration management:** Ansible playbooks

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,40 @@
+# Infrastructure
+
+This directory contains deployment and configuration resources for the platform.
+
+## Development: Docker Compose
+
+Use the files in `docker/` to launch a local stack:
+
+```bash
+cd docker
+docker compose up -d
+```
+
+This environment is intended for local testing and mirrors production services on a smaller scale.
+
+## Production: Kubernetes
+
+Kubernetes manifests live in `kubernetes/`. Provision cloud resources with Terraform before applying the manifests:
+
+```bash
+cd terraform
+terraform init
+terraform apply
+cd ../kubernetes
+kubectl apply -k .
+```
+
+Helm or Kustomize may be used to manage production deployments.
+
+## Infrastructure as Code
+
+- **Terraform** configurations in `terraform/` provision cloud infrastructure.
+- **Ansible** playbooks in `ansible/` manage configuration for servers and services.
+
+## Scaling Considerations
+
+- Use Kubernetes Horizontal Pod Autoscalers to scale application pods based on load.
+- Ensure stateful services use managed offerings or persistent volumes that support scaling.
+- Review resource requests and limits in manifests to avoid overcommitment.
+- For development, Docker Compose is not intended for high availability or scaling.


### PR DESCRIPTION
## Summary
- document infrastructure scope and criticality
- outline deployment steps for development and production environments

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947b690774832a87dcf5c4394e5877