### PR TITLE
docs(desktop): add agent and build guide

### DIFF
--- a/frontend/desktop/AGENT.md
+++ b/frontend/desktop/AGENT.md
@@ -1,0 +1,9 @@
+- **Criticality**: 9/10
+- **Purpose**: Desktop application using Tauri
+- **Files**:
+  - `src-tauri/` (Rust backend)
+  - `src/` (React frontend)
+  - `tauri.conf.json`
+- **Framework**: Tauri for native performance
+- **Features**: System tray, settings, dashboard snapshot
+- **Platform builds**: Windows MSI, macOS DMG, Linux DEB/RPM

--- a/frontend/desktop/README.md
+++ b/frontend/desktop/README.md
@@ -1,0 +1,56 @@
+# Desktop Application
+
+This directory contains the Tauri-based desktop client. The app combines a React frontend with a Rust backend to deliver native performance and a small footprint.
+
+## Prerequisites
+
+- Node.js and [pnpm](https://pnpm.io/) installed
+- Rust toolchain with `cargo`
+- Tauri CLI (`pnpm add -g @tauri-apps/cli` or `cargo install tauri-cli`)
+- Platform build tools (Xcode on macOS, Visual Studio Build Tools on Windows, required GTK libraries on Linux)
+
+## Building
+
+Run all commands from this folder.
+
+### Windows (MSI)
+```bash
+pnpm tauri build --target x86_64-pc-windows-msvc
+```
+
+**Signing:** provide a `.pfx` code-signing certificate and expose it to Tauri via:
+```powershell
+set TAURI_WINDOWS_CERTIFICATE=path\to\cert.pfx
+set TAURI_WINDOWS_PASSWORD=yourPassword
+```
+
+### macOS (DMG)
+```bash
+pnpm tauri build --target aarch64-apple-darwin
+```
+
+**Signing:** requires an Apple Developer ID Application certificate:
+```bash
+export APPLE_CERTIFICATE="/path/to/cert.p12"
+export APPLE_CERTIFICATE_PASSWORD="password"
+export APPLE_TEAM_ID="YOURTEAMID"
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+```
+
+### Linux (DEB/RPM)
+```bash
+pnpm tauri build --target x86_64-unknown-linux-gnu
+```
+
+**Signing:** sign packages with GPG:
+```bash
+gpg --detach-sign --armor path/to/app_*.deb
+gpg --detach-sign --armor path/to/app-*.rpm
+```
+
+## Development
+
+To run in development mode with hot reload:
+```bash
+pnpm tauri dev
+```


### PR DESCRIPTION
## Summary
- document critical Tauri desktop components and platform builds in `frontend/desktop/AGENT.md`
- add cross-platform build and signing instructions to `frontend/desktop/README.md`

## Testing
- `pnpm test` *(failed: Request was cancelled)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947b55f910832a9ef37b741715a3b1