### PR TITLE
docs: add aw-server-rust agent and readme

### DIFF
--- a/backend/services/aw-server-rust/AGENT.md
+++ b/backend/services/aw-server-rust/AGENT.md
@@ -1,0 +1,10 @@
+# aw-server-rust Agent
+
+- **Criticality:** 10/10
+- **Purpose:** Event ingestion and raw storage
+- **Files:** src/main.rs, src/ingestion/ (batch.rs, validator.rs), src/storage/ (postgres.rs, kafka.rs, minio.rs), src/models/
+- **Receives:** EventBatch from Event Gateway
+- **Writes to:** PostgreSQL (events_raw table), Kafka (events_raw topic), MinIO (audio metadata)
+- **Partitioning:** By month and user_id hash
+- **Throughput:** 10k events/second target
+

--- a/backend/services/aw-server-rust/README.md
+++ b/backend/services/aw-server-rust/README.md
@@ -1,0 +1,22 @@
+# aw-server-rust
+
+## Event Validation
+Incoming `EventBatch` messages are validated to ensure each event conforms to the expected schema and tenant policies before any storage occurs. The validator checks timestamps, required fields, and user identifiers to prevent malformed data from entering the system.
+
+## Storage Strategy
+Validated events are inserted into the `events_raw` table in PostgreSQL. Logical replication publishes changes to the `events_raw` Kafka topic for downstream consumers. Audio object metadata is written to MinIO while the raw audio is stored separately, keeping only hashes and metadata in the database. Data is partitioned by month and a hash of `user_id` to distribute load evenly.
+
+## TimescaleDB Hypertable Configuration
+`events_raw` is configured as a TimescaleDB hypertable to support high write throughput and efficient time-based queries. A typical setup:
+
+```sql
+SELECT create_hypertable(
+    'events_raw',
+    'timestamp',
+    partitioning_column => 'user_id_hash',
+    number_partitions => 32,
+    chunk_time_interval => INTERVAL '1 month'
+);
+```
+
+This configuration partitions data monthly and shards by the hashed `user_id`, enabling horizontal scalability and fast lookups.


### PR DESCRIPTION
## Summary
- document aw-server-rust with agent responsibilities and throughput target
- describe event validation, storage strategy, and TimescaleDB setup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68947af467b8832a9b0521e2fc047207