### PR TITLE
docs: add dashboard guidelines

### DIFF
--- a/dashboards/AGENT.md
+++ b/dashboards/AGENT.md
@@ -1,0 +1,7 @@
+- **Criticality:** 8/10
+- **Purpose:** Grafana dashboard definitions
+- **Files:** productivity.json, emotions.json, ai-usage.json, vibe-social.json, team-metrics.json, developer-analytics.json
+- **Data source:** PostgreSQL with TimescaleDB
+- **Refresh rates:** 30 seconds for real-time, hourly for aggregates
+- **Variables:** User, project, date range
+

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,0 +1,21 @@
+# Dashboards
+
+This directory contains Grafana dashboard JSON definitions for productivity, emotions, AI usage, social vibes, team metrics, and developer analytics.
+
+## Importing Dashboards
+1. Open your Grafana instance.
+2. Navigate to **Dashboards → Import**.
+3. Upload one of the JSON files from this folder or paste its contents.
+4. Select the PostgreSQL with TimescaleDB data source when prompted.
+
+## Customizing Panels
+- Open a dashboard and click **Edit** on any panel.
+- Adjust the query, visualization type, thresholds, and refresh interval.
+- Use the built-in variables `User`, `project`, and `date range` to filter data.
+
+## Creating New Visualizations
+1. From an existing dashboard, choose **Add panel** or start a new dashboard.
+2. Build queries against the PostgreSQL TimescaleDB data source.
+3. Set appropriate refresh rates: 30 seconds for real-time panels, hourly for aggregate panels.
+4. Save the dashboard and export its JSON into this directory to version control it.
+


### PR DESCRIPTION
## Summary
- add AGENT info for dashboard definitions
- document importing and customizing Grafana dashboards

## Testing
- `cargo test`
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947b606570832ab36f4308ea946fff