### PR TITLE
docs(browser-extension): add agent instructions and readme

### DIFF
--- a/frontend/browser-extension/AGENT.md
+++ b/frontend/browser-extension/AGENT.md
@@ -1,0 +1,9 @@
+# AGENT Instructions
+
+- **Criticality**: 10/10
+- **Purpose**: Browser activity tracking extension
+- **Files**: manifest.v3.json (Manifest V3), src/background/ (service worker), src/content/ (content scripts), src/popup/ (extension popup)
+- **Tracks**: URLs, tab focus, AI chat detection, scroll depth
+- **Classification**: Research vs casual browsing
+- **Communication**: WebSocket to localhost:8081
+- **Supported browsers**: Chrome, Firefox, Edge, Brave, Safari

--- a/frontend/browser-extension/README.md
+++ b/frontend/browser-extension/README.md
@@ -1,0 +1,22 @@
+# Browser Extension
+
+This extension tracks browser activity for iVibe.live.
+
+## Installation
+1. Clone the repository and navigate to `frontend/browser-extension`.
+2. In Chrome, Edge, or Brave:
+   - Open `chrome://extensions`.
+   - Enable **Developer mode**.
+   - Choose **Load unpacked** and select this folder.
+3. In Firefox:
+   - Open `about:debugging#/runtime/this-firefox`.
+   - Click **Load Temporary Add-on** and select `manifest.v3.json`.
+4. Safari uses the **Develop > Show Web Extension** menu from Safari 14 and later.
+
+## Permissions
+- **Tabs**: read the active tab URL and track focus time.
+- **Scripting**: inject content scripts to measure scroll depth and detect AI chats.
+- **Storage**: retain local state between sessions.
+
+## Privacy
+Captured data is sent only to a local WebSocket at `ws://localhost:8081` and is never transmitted to third-party servers. The extension classifies visits as research or casual browsing and records URLs, tab focus, AI chat usage, and scroll depth for personal analytics.


### PR DESCRIPTION
## Summary
- document browser extension scope and requirements in AGENT.md
- add README with install steps, permissions and privacy notes

## Testing
- `pnpm test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947b4fc0b4832ab67c5cf80a5ff5eb