### PR TITLE
docs: add web frontend guidelines

### DIFF
--- a/frontend/web/AGENT.md
+++ b/frontend/web/AGENT.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+- Criticality: 10/10
+- Purpose: Main web application
+- Files: package.json, index.html, src/main.tsx (entry), src/App.tsx
+- Components: dashboard/, settings/, vibe/, common/
+- State management: Redux with slices (auth, dashboard)
+- API communication: REST client, WebSocket for real-time
+- Routing: React Router for SPA navigation

--- a/frontend/web/README.md
+++ b/frontend/web/README.md
@@ -1,0 +1,20 @@
+# Web Frontend
+
+## Component Hierarchy
+- `src/main.tsx` bootstraps React and Redux and renders the app.
+- `src/App.tsx` defines the top-level layout and React Router navigation.
+- `src/components` groups UI components by domain:
+  - `dashboard/`
+  - `settings/`
+  - `vibe/`
+  - `common/`
+
+## State Management
+- Redux Toolkit manages global state.
+- Slices in `src/store` include `auth.slice.ts` and `dashboard.slice.ts`.
+- The configured store is provided through React Redux `<Provider>` in `src/main.tsx`.
+
+## API Integration
+- REST requests are handled through the client in `src/services/api.ts`.
+- Real-time updates use a WebSocket connection from `src/services/websocket.ts`.
+- Authentication helpers live in `src/services/auth.ts` and interact with the REST API.


### PR DESCRIPTION
## Summary
- add AGENT instructions for web frontend
- document component structure, state management, and API integration

## Testing
- `pnpm -v` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `npm test --prefix frontend/web` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947b4a2e68832a93de7ed9118f3d17