### PR TITLE
docs(frontend): add agent and readme

### DIFF
--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -1,0 +1,18 @@
+# Frontend
+
+- **Criticality**: 10/10
+- **Purpose**: TypeScript/React frontend applications
+- **Files**:
+  - `package.json`
+  - `pnpm-lock.yaml` (criticality: 10)
+  - `tsconfig.json`
+  - `vite.config.ts`
+  - `.eslintrc.js`
+  - `.prettierrc`
+- **Subdirectories**:
+  - `web/`
+  - `browser-extension/`
+  - `desktop/`
+- **Package Manager**: pnpm with frozen lockfile
+- **Build**: Vite for development and production
+- **Monorepo**: pnpm workspaces

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,33 @@
+# Frontend
+
+This directory contains the TypeScript/React frontend applications for the project. It is structured as a pnpm monorepo with three packages:
+
+- **web/** – main web client
+- **browser-extension/** – browser watcher and UI
+- **desktop/** – desktop shell
+
+## Development
+
+1. Install dependencies with a frozen lockfile:
+
+   ```bash
+   pnpm install --frozen-lockfile
+   ```
+
+2. Start a development server for a package:
+
+   ```bash
+   pnpm --filter <package> dev
+   ```
+
+   Replace `<package>` with `web`, `browser-extension`, or `desktop`.
+
+## Build for Production
+
+Build any package using Vite:
+
+```bash
+pnpm --filter <package> build
+```
+
+The compiled assets will be written to the respective `dist/` directories.


### PR DESCRIPTION
## Summary
- document frontend workspace structure and build tooling
- describe dev server and production build commands

## Testing
- `pnpm install --frozen-lockfile` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68947b4486b4832aa49678b6f48c3144