### PR TITLE
docs: document ETL orchestrator

### DIFF
--- a/backend/services/etl-orchestrator/AGENT.md
+++ b/backend/services/etl-orchestrator/AGENT.md
@@ -1,0 +1,20 @@
+# ETL Orchestrator
+
+- **Criticality:** 8/10
+- **Purpose:** Data aggregation and retention management
+- **Files:**
+  - `src/main.rs`
+  - `src/scheduler.rs`
+  - `src/jobs/`
+    - `materialized_views.rs`
+    - `retention.rs`
+    - `exports.rs`
+  - `src/stripe/`
+    - `usage.rs`
+- **Materialized views:**
+  - `mv_time_by_language`
+  - `mv_errors_fixed`
+  - `mv_token_usage`
+- **Retention:** Tier-based (7 days free, 14 days essential, unlimited pro)
+- **Exports:** CSV, JSON, PDF generation
+- **Stripe:** Weekly seat count reconciliation

--- a/backend/services/etl-orchestrator/README.md
+++ b/backend/services/etl-orchestrator/README.md
@@ -1,0 +1,18 @@
+# ETL Orchestrator
+
+The service coordinates scheduled jobs that aggregate data, enforce retention limits, and provide exports.
+
+## ETL Schedules
+- **Hourly**: refresh `mv_time_by_language`
+- **Daily**: refresh `mv_errors_fixed` and `mv_token_usage`
+- **Nightly**: apply tier-based retention cleanup
+- **Weekly**: reconcile seat usage with Stripe and generate exports
+
+## View Refresh Strategies
+- Uses materialized views to precompute heavy queries
+- Hourly views use incremental refresh; daily views run a full rebuild
+
+## Data Retention Policies
+- **Free**: 7 days of data
+- **Essential**: 14 days of data
+- **Pro**: unlimited retention


### PR DESCRIPTION
## Summary
- document ETL orchestrator responsibilities, criticality, and key files
- add README outlining ETL schedules, view refresh strategies, and tier-based retention policies

## Testing
- `cargo test -p etl-orchestrator`


------
https://chatgpt.com/codex/tasks/task_e_68947b07040c832aa6812fd6ab3c70d0