### PR TITLE
docs: document aw-watcher-window

### DIFF
--- a/backend/watchers/aw-watcher-window/AGENT.md
+++ b/backend/watchers/aw-watcher-window/AGENT.md
@@ -1,0 +1,21 @@
+# aw-watcher-window – Agent Instructions
+
+## Capture Details
+- Record `window_title`, `app_name`, and `file_path` every 1-5 seconds.
+- Batch events to the Event Gateway via gRPC, sending when batch reaches 100 events or every 5 seconds.
+
+## Platform Hooks
+- **Linux:** Uses `_NET_ACTIVE_WINDOW` through X11/DBus. Fall back to the proc filesystem if X11 is unavailable.
+- **Windows:** Relies on `EVENT_SYSTEM_FOREGROUND` via the Win32 API.
+- **macOS:** Uses `NSWorkspace` from the Accessibility API.
+
+## Dependencies
+- `x11`
+- `winapi`
+- `cocoa`
+- `tokio`
+- `tonic`
+
+## Testing
+- `cargo test --locked`
+- Attempt to run `cargo audit` and `cargo deny`

--- a/backend/watchers/aw-watcher-window/README.md
+++ b/backend/watchers/aw-watcher-window/README.md
@@ -1,0 +1,11 @@
+# aw-watcher-window
+
+Cross-platform desktop window focus tracker.
+
+## Platform Capture Methods
+- **Linux:** Hooks into `_NET_ACTIVE_WINDOW` via X11/DBus. If X11 is absent, the watcher reads the `/proc` filesystem for active window metadata.
+- **Windows:** Uses the Win32 `EVENT_SYSTEM_FOREGROUND` event to detect focus changes.
+- **macOS:** Leverages `NSWorkspace` through the Accessibility API to monitor the frontmost application.
+
+## Event Batching
+Captured events contain the window title, application name, and file path. Events are batched and sent to the Event Gateway over gRPC when either 100 events are collected or 5 seconds have passed, whichever comes first.


### PR DESCRIPTION
## Summary
- add AGENT instructions for aw-watcher-window
- document platform-specific capture logic and batching

## Testing
- `cargo test --locked`
- `cargo audit` *(fails: no such command)*
- `cargo install cargo-audit` *(fails: failed to download config.json: 403)*
- `cargo deny check` *(fails: no such command)*
- `cargo install cargo-deny` *(fails: failed to download config.json: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68947671a858832ab5f9c575892a6949