### PR TITLE
docs: add backend agent and readme

### DIFF
--- a/backend/AGENT.md
+++ b/backend/AGENT.md
@@ -1,0 +1,19 @@
+# Backend Agent Guide
+
+This directory hosts the core Rust services with criticality **10**. It contains watchers, processing services, intelligence engines, APIs, the CLI, and shared modules.
+
+## Workspace
+
+- Manage crates through the root `Cargo.toml` workspace file and keep all member crates listed.
+- Build all modules together so they share proto definitions and models.
+
+## Dependencies and Security
+
+- Pin dependencies via the committed `Cargo.lock` for reproducible builds.
+- Enforce supply-chain security by running `cargo deny`.
+
+## Communication
+
+- Receives data from all capture sources.
+- Sends data to PostgreSQL, Kafka, Redis, and MinIO.
+- Uses gRPC internally and REST/GraphQL for external APIs.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,40 @@
+# iVibe Backend
+
+The `backend` directory contains the Rust-based core of iVibe's services. It is the heart of the platform and houses watchers, processing services, intelligence engines, APIs, the command-line interface, and shared modules.
+
+## Workspace Structure
+
+- `Cargo.toml` – Workspace root listing all member crates
+- `Cargo.lock` – Locked dependencies for reproducible builds
+- `deny.toml` – Configuration for `cargo deny`
+- `watchers/` – Capture modules
+- `services/` – Processing services
+- `intelligence/` – AI and social engines
+- `api/` – REST and GraphQL endpoints
+- `cli/` – Command-line interface
+- `shared/` – Common models and utilities
+
+## Building
+
+Build every crate in the workspace with locked dependencies:
+
+```bash
+cargo build --workspace --locked
+```
+
+## Testing
+
+Run all tests across the workspace:
+
+```bash
+cargo test --workspace --all-targets
+```
+
+## Security Auditing
+
+Check dependencies for supply-chain issues:
+
+```bash
+cargo deny check
+cargo audit
+```


### PR DESCRIPTION
## Summary
- document backend workspace expectations and communication protocols in `AGENT.md`
- add `README.md` describing backend architecture and build/test/audit commands

## Testing
- `cargo fmt --all`
- `cargo test --workspace --all-targets`
- `cargo deny check` *(fails: no such command and install failed with 403)*
- `cargo audit` *(fails: no such command and install failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_689476577df0832aa56e52282c9c7aea