### PR TITLE
docs: add watcher guidelines and overview

### DIFF
--- a/backend/watchers/AGENT.md
+++ b/backend/watchers/AGENT.md
@@ -1,0 +1,17 @@
+# Watcher Development Guide
+
+This directory contains data capture modules with **criticality 10**.
+
+## Guidelines
+- Each watcher captures its platform-specific events and forwards them to the Event Gateway via gRPC.
+- Batch events and send when **512 events** are collected or **5 seconds** have elapsed.
+- Implement the `EventBatch` protocol from the shared protobuf definitions.
+- Use gRPC over TLS, targeting port **50051**.
+- Authentication must use **JWT tokens** issued by Keycloak.
+
+## Platform Notes
+- **Window watcher:** utilise DBus on Linux, Win32 APIs on Windows, and Cocoa on macOS.
+- **Terminal watcher:** hook into user shells to observe executed commands.
+- **Audio watcher:** capture raw PCM frames for later vectorisation.
+
+These requirements apply to all subdirectories within `watchers`.

--- a/backend/watchers/README.md
+++ b/backend/watchers/README.md
@@ -1,0 +1,25 @@
+# Watchers
+
+## Architecture
+Watchers capture platform-specific activity and transmit it to the Event Gateway.
+
+- Events are buffered and dispatched when 512 items accumulate or after 5 seconds.
+- Batches conform to the shared `EventBatch` protobuf and are sent via gRPC over TLS on port 50051.
+- Authentication uses JWT tokens issued by Keycloak.
+
+## Event Schema
+Each `Event` in a batch includes:
+
+- `event_id` – unique identifier (uuid4)
+- `user_id` – watcher owner (uuid4)
+- `timestamp` – RFC3339
+- `source` – e.g. `window`, `kdevelop`, `terminal`, `audio`
+- `project` – optional project association
+- `language` – programming language where relevant
+- `payload` – watcher-specific fields such as window title, command, or audio metadata
+
+## Platform-Specific Implementations
+- **aw-watcher-window** – tracks active windows using DBus (Linux), Win32 (Windows), or Cocoa (macOS).
+- **aw-watcher-kdevelop** – KDevelop plugin emitting editor events for file edits, builds, and debugging sessions.
+- **aw-watcher-terminal** – hooks into supported shells to record executed commands and exit statuses.
+- **aw-watcher-audio** – records PCM audio frames for downstream vectorisation.


### PR DESCRIPTION
## Summary
- document watcher batch, transport, and auth guidelines
- add architecture and event schema overview for watchers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68947668618c832a8f161651188e62f7