### PR TITLE
docs: document automation scripts

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,24 @@
+# Automation Script Guidelines
+
+This directory contains critical build, deployment, setup, and billing automation. Follow these conventions when updating scripts.
+
+## Build Scripts
+- Compile Rust projects with `--locked` to enforce `Cargo.lock`.
+- Install TypeScript dependencies using a frozen lockfile (e.g., `npm ci --frozen-lockfile`).
+- Fail builds on dependency drift.
+
+## Deployment Scripts
+- Build and push Docker images before rollout.
+- Apply Kubernetes manifests.
+- Include post-deployment health checks and rollback logic.
+
+## Setup Scripts
+- Install and configure Rust, Node.js, Docker, and PostgreSQL for development environments.
+
+## Stripe Scripts
+- Use the Stripe CLI to create products and prices.
+- Configure webhook endpoints for billing events.
+
+## Security
+- Generate cryptographic keys for JWT signing and encryption.
+- Never commit secrets; store them in secure vaults.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,37 @@
+# Automation Scripts
+
+These scripts automate build, deployment, environment setup, and Stripe billing tasks for the iVibe.live project.
+
+## Directory Layout
+- `build/`
+  - `build-all.sh`
+  - `build-rust.sh`
+  - `build-frontend.sh`
+- `deploy/`
+  - `deploy-prod.sh`
+  - `rollback.sh`
+- `setup/`
+  - `dev-setup.sh`
+  - `install-deps.sh`
+  - `generate-keys.sh`
+- `stripe/`
+  - `create-products.sh`
+  - `setup-webhooks.sh`
+
+## Prerequisites
+- Unix-like shell environment
+- Rust toolchain
+- Node.js
+- Docker
+- PostgreSQL
+- Stripe CLI
+- Access to Docker registry and Kubernetes cluster for deploy scripts
+
+## Usage
+1. **Setup**: run `setup/install-deps.sh` and `setup/dev-setup.sh` to prepare the environment. `setup/generate-keys.sh` creates JWT and encryption keys.
+2. **Build**: run `build/build-all.sh` to compile Rust (`--locked`) and TypeScript (`--frozen-lockfile`) components.
+3. **Deploy**: `deploy/deploy-prod.sh` builds and pushes Docker images, applies Kubernetes manifests, and verifies health. Use `deploy/rollback.sh` to revert if necessary.
+4. **Stripe**: `stripe/create-products.sh` and `stripe/setup-webhooks.sh` configure billing via the Stripe CLI.
+
+## Workflow
+The typical automation workflow is: setup → build → deploy → stripe provisioning. These scripts are critical to the platform; review changes carefully and test in staging before production.


### PR DESCRIPTION
## Summary
- add guidelines for build, deploy, setup, stripe, and security automation
- document script layout, prerequisites, and workflow

## Testing
- `npm test` (fails: Missing script "test")
- `cargo test --locked` (backend/services/stripe-webhook-handler)


------
https://chatgpt.com/codex/tasks/task_e_689476cfd0b8832aaf32181b77615742