### PR TITLE
docs: add test suite guidelines

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,25 @@
+# Tests Directory Instructions
+
+This directory contains all automated test suites for the project. These tests are critical (criticality level 7) and run on every commit via CI.
+
+## Structure
+- `e2e/`
+  - `cypress/`: End-to-end tests covering full user flows using Cypress.
+  - `playwright/`: Cross-browser end-to-end tests implemented with Playwright.
+- `integration/`
+  - `api/`: API endpoint tests.
+  - `services/`: Tests verifying inter-service communication.
+- `load/`
+  - `k6/`: API load scripts executed with 100 virtual users for 10 minutes.
+  - `locust/`: Complex scenario load tests defined in `locustfile.py`.
+- `security/`
+  - `zap/`: Automated OWASP ZAP scanning.
+  - `burp/`: Manual and automated Burp Suite testing assets.
+
+## Guidelines
+- End-to-end tests model realistic user journeys through Cypress or Playwright.
+- Integration tests validate API endpoints and service interactions.
+- Load testing uses k6 (`k6 run --vus 100 --duration 10m`) for standard API load and Locust for complex scenarios.
+- Security testing leverages OWASP ZAP and Burp Suite to detect vulnerabilities.
+- Unit test suites across the codebase must maintain at least 80% coverage.
+- All tests are executed in CI on every commit.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,48 @@
+# Test Strategy and Execution
+
+This folder aggregates all automated test suites for the project with a criticality level of 7. The strategy spans unit, integration, end-to-end, load, and security testing to ensure robust coverage and reliability.
+
+## Directory Structure
+- `e2e/`
+  - `cypress/`
+  - `playwright/`
+- `integration/`
+  - `api/`
+  - `services/`
+- `load/`
+  - `k6/scenarios/`
+  - `locust/locustfile.py`
+- `security/`
+  - `zap/`
+  - `burp/`
+
+## Running Tests
+### Unit Tests
+Run the unit test suites from their respective packages. A minimum of 80% coverage is required.
+
+### End-to-End
+```bash
+npm run test:e2e:cypress
+npm run test:e2e:playwright
+```
+
+### Integration
+```bash
+npm run test:integration:api
+npm run test:integration:services
+```
+
+### Load
+```bash
+k6 run --vus 100 --duration 10m load/k6/<script.js>
+locust -f load/locust/locustfile.py
+```
+
+### Security
+```bash
+zap-cli quick-scan http://localhost:8080
+# Burp Suite tests are executed manually or via configured automation
+```
+
+## CI/CD Integration
+All test suites are executed in the continuous integration pipeline for every commit and pull request. Coverage thresholds are enforced to guarantee at least 80% unit test coverage.


### PR DESCRIPTION
## Summary
- document test suite structure and guidelines in `tests/AGENTS.md`
- add `tests/README.md` describing strategy and how to run tests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689476de6f08832a8c25aade76f89007