### PR TITLE
docs(shared): add guidelines and usage docs

### DIFF
--- a/backend/shared/AGENT.md
+++ b/backend/shared/AGENT.md
@@ -1,0 +1,19 @@
+# AGENT
+
+- Criticality: 9/10
+- Purpose: Shared libraries and utilities
+- Subdirectories:
+  - proto (protobuf definitions)
+  - models (data models)
+  - utils (crypto, telemetry)
+- Proto files:
+  - events.proto
+  - gateway.proto
+  - vibe.proto
+- Models:
+  - Event struct
+  - User struct
+  - Vibe struct
+- Utils:
+  - AES-256 encryption
+  - OpenTelemetry tracing

--- a/backend/shared/README.md
+++ b/backend/shared/README.md
@@ -1,0 +1,46 @@
+# Shared Libraries and Utilities
+
+This directory hosts common code used across backend services, including protobuf definitions, data models, and reusable utilities.
+
+## Protobuf Definitions
+
+Protobuf files live under [`proto/src/proto`](proto/src/proto):
+
+- `events.proto`
+- `gateway.proto`
+- `vibe.proto`
+
+### Regenerating Code
+
+To regenerate Rust types from the `.proto` files, run:
+
+```
+cd backend/shared/proto
+protoc --proto_path=src/proto --rust_out=src/proto src/proto/*.proto
+```
+
+Ensure `protoc` and the Rust plugin are installed before running the command.
+
+## Data Models
+
+The `models` crate exposes shared structs used throughout the backend:
+
+- `Event`
+- `User`
+- `Vibe`
+
+These types provide a common representation for events and user context.
+
+## Utilities
+
+The `utils` crate offers reusable helpers:
+
+- `crypto` for AES-256 encryption helpers
+- `telemetry` for OpenTelemetry tracing setup
+
+```
+use utils::crypto::encrypt_aes256;
+use utils::telemetry::init_tracer;
+```
+
+Refer to each module for additional details and configuration options.


### PR DESCRIPTION
## Summary
- add high-level AGENT overview for shared libs, models, and utilities
- document protobuf regeneration steps and utility usage in README

## Testing
- `cargo test -p proto -p models -p utils`


------
https://chatgpt.com/codex/tasks/task_e_68947b3f6e98832a9f6e1eda777aad77