### PR TITLE
docs: add public profile service docs

### DIFF
--- a/backend/services/public-profile-api/AGENT.md
+++ b/backend/services/public-profile-api/AGENT.md
@@ -1,0 +1,7 @@
+Criticality: 7/10
+Purpose: Privacy-filtered public profile serving
+Files: src/main.rs, src/handlers.rs, src/privacy/ (bitmask.rs), src/cache.rs, templates/profile.html
+Endpoint: /u/{handle}
+Privacy: Bitmask filtering of private fields
+Caching: Redis with 60-second TTL
+Output: HTML via templates, JSON for API

--- a/backend/services/public-profile-api/README.md
+++ b/backend/services/public-profile-api/README.md
@@ -1,0 +1,17 @@
+# Public Profile API
+
+This service exposes privacy-filtered public profiles for iVibe users. The endpoint `/u/{handle}` renders the profile as HTML for browsers and provides JSON for API clients.
+
+## Privacy Controls
+Profiles are filtered using a bitmask scheme. Each field in the profile has an associated bit; when a user marks a field as private, its bit is cleared and the field is removed from the public view. Only data with the corresponding bit set is returned.
+
+### Publicly Shareable Data
+Users may choose to expose:
+- basic profile information such as handle or avatar
+- selected activity summaries and metrics
+- any other fields explicitly marked as public
+
+All other data remains private and is stripped before rendering.
+
+## Caching and Invalidation
+Rendered profiles are cached in Redis with a 60-second TTL to reduce load. The cache entry expires automatically after the TTL or when profile data changes, ensuring updates appear promptly.


### PR DESCRIPTION
## Summary
- add AGENT guidelines for Public Profile API
- document privacy controls, public data, and cache invalidation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68947b0d229c832ab5fddc3b4b100f0b