### PR TITLE
docs: add watcher guidelines and overview

### DIFF
--- a/backend/watchers/AGENT.md
+++ b/backend/watchers/AGENT.md
@@ -1,0 +1,13 @@
+# Watchers
+
+- **Criticality:** 10/10
+- **Purpose:** Data capture modules for all platforms
+- **Subdirectories:**
+  - `aw-watcher-window` (criticality: 10)
+  - `aw-watcher-kdevelop` (criticality: 10)
+  - `aw-watcher-terminal` (criticality: 10)
+  - `aw-watcher-audio` (criticality: 8)
+- **Communication:** Each watcher → Event Gateway via gRPC over TLS
+- **Event batch size:** 100 events or 5 seconds
+- **Protocols:** gRPC with protobuf serialization
+- **Platform-specific:** Linux (DBus, X11), Windows (Win32 API), macOS (Accessibility API)

--- a/backend/watchers/README.md
+++ b/backend/watchers/README.md
@@ -1,0 +1,17 @@
+# Watchers
+
+Platform-specific collectors that capture user activity and stream events to the Event Gateway. Each watcher buffers up to 100 events or 5 seconds before sending a batch over gRPC with protobuf serialization and TLS.
+
+## Modules
+
+### aw-watcher-window
+Captures active window titles and focus events across desktop environments using DBus and X11 on Linux, the Win32 API on Windows, and the Accessibility API on macOS.
+
+### aw-watcher-kdevelop
+Monitors the KDevelop IDE, recording opened files, project context, and branch information through DBus signals.
+
+### aw-watcher-terminal
+Observes shell sessions, logging executed commands, exit codes, and error output for supported shells.
+
+### aw-watcher-audio
+Streams microphone activity and optional hotword detections while applying privacy filters before vectorization.


### PR DESCRIPTION
## Summary
- document watcher modules and their criticality
- explain how watchers batch and stream events to the gateway

## Testing
- `cargo test -p aw-watcher-window -p aw-watcher-kdevelop -p aw-watcher-terminal -p aw-watcher-audio --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68947a1e9b6c832aa509d6e3baae8c8c