### PR TITLE
docs: document Android module services and architecture

### DIFF
--- a/mobile/android/AGENT.md
+++ b/mobile/android/AGENT.md
@@ -1,0 +1,29 @@
+# Android Mobile Client Guidelines
+
+**Criticality:** 10 – this module handles sensitive user data.
+
+## Services
+- **TrackerService** – foreground service tracking app usage and coordinating other services.
+- **EmotionService** – processes camera frames to infer emotional state.
+- **LocationService** – records GPS updates for context.
+- **VibeService** – captures audio, vectorises locally, and computes vibe scores.
+
+## Permissions
+The app requires the following permissions. Review carefully before adding more:
+- `RECORD_AUDIO`
+- `CAMERA`
+- `LOCATION`
+- `BLUETOOTH`
+- `PACKAGE_USAGE_STATS`
+
+## FFI
+Kotlin talks to Rust through a JNI bridge in `app/src/main/java/live/ivibe/ffi`. Rust libraries in `app/libs/` perform on-device audio vectorisation and vibe scoring.
+
+## Communication
+All uploads use HTTPS to `https://api.ivibe.live/mobile`.
+
+## Bluetooth
+Vibe detection uses BLE beacon broadcasting. Use Android's `BluetoothLeAdvertiser` APIs and handle permissions gracefully.
+
+## Storage
+Audio and sensor data are vectorised on-device. Batches are stored locally and uploaded every 5 minutes.

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -1,0 +1,10 @@
+# iVibe Android Client
+
+## Architecture
+The application is composed of multiple services managed by `TrackerService`, a foreground service that keeps the process alive and coordinates background work. `EmotionService` analyses camera frames, `LocationService` reports GPS context, and `VibeService` captures audio and computes vibe scores using on-device Rust code. BLE beacon broadcasting enables nearby vibe detection, while all outbound data is sent over HTTPS to `api.ivibe.live/mobile`.
+
+## Permission Flow
+On first run the app requests runtime permissions for `RECORD_AUDIO`, `CAMERA`, `LOCATION`, `BLUETOOTH`, and `PACKAGE_USAGE_STATS`. Each feature should check its permission before starting; deny or revoke events must disable the related service and prompt the user to re-enable it in settings.
+
+## Rust Integration
+Rust libraries compiled into `app/libs/` are accessed through JNI bindings under `app/src/main/java/live/ivibe/ffi`. Audio frames are vectorised and scored in Rust, with results stored on-device until batches are uploaded every five minutes.


### PR DESCRIPTION
## Summary
- add AGENT instructions for Android client services, permissions, and Rust FFI
- document Android architecture and permission flow in new README

## Testing
- `gradle help`


------
https://chatgpt.com/codex/tasks/task_e_689476b0bfac832ab05da7341a854ea0