### PR TITLE
docs(frontend): add guidelines and overview

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,30 @@
+# Frontend Guidelines
+
+This directory contains all TypeScript/React client applications with **criticality 10**.
+
+## Monorepo
+- Managed as a pnpm workspace; shared config lives in this folder.
+- Subpackages:
+  - `web/` – React web app
+  - `browser-extension/` – Manifest V3 extension
+  - `desktop/` – Tauri desktop app
+
+## Communication
+- Use REST and GraphQL requests to backend APIs.
+- Establish a WebSocket connection to port `8081` for real-time features.
+
+## Build
+- Web and extension projects are built with **Vite**.
+- Desktop app uses **Tauri** for bundling and native integration.
+
+## Authentication
+- JWT access tokens are stored in `localStorage` after login and sent in API requests.
+
+## Real-time
+- Open a WebSocket to `ws://localhost:8081` for live updates.
+
+## Dependencies
+- React
+- TypeScript
+- `@tanstack/react-query`
+- `recharts`

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,32 @@
+# Frontend Overview
+
+The frontend consists of three TypeScript/React applications managed in a single pnpm workspace:
+
+- **web/** – Vite-powered web client
+- **browser-extension/** – Manifest V3 extension built with Vite
+- **desktop/** – Tauri desktop application
+
+All clients communicate with backend REST and GraphQL APIs and use a WebSocket on port `8081` for live updates. Authentication uses JWTs stored in `localStorage`.
+
+## Development Setup
+
+1. Install prerequisites:
+   - Node.js 20+
+   - pnpm 8+
+   - Rust (for Tauri desktop app)
+2. Install workspace dependencies:
+   ```bash
+   pnpm install
+   ```
+3. Start development servers:
+   - Web: `pnpm --filter web dev`
+   - Browser extension: `pnpm --filter browser-extension dev`
+   - Desktop: `pnpm --filter desktop tauri dev`
+
+## Deployment
+
+- **Web**: `pnpm --filter web build` creates a production bundle in `web/dist`.
+- **Browser extension**: `pnpm --filter browser-extension build` outputs the packaged extension in `browser-extension/dist`.
+- **Desktop**: `pnpm --filter desktop tauri build` generates platform-specific installers.
+
+The applications depend on React, TypeScript, `@tanstack/react-query`, and `recharts`.


### PR DESCRIPTION
## Summary
- add frontend AGENTS file with workspace, communication, build, auth, and dependency details
- document architecture, development, and deployment steps in frontend README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")


------
https://chatgpt.com/codex/tasks/task_e_689476962e8c832a8232dbeb6e62d7f4