### PR TITLE
docs: add web frontend guides

### DIFF
--- a/frontend/web/AGENT.md
+++ b/frontend/web/AGENT.md
@@ -1,0 +1,29 @@
+# Web Frontend Agent
+
+Criticality: **10** – primary user interface for dashboards and settings.
+
+## Routes
+- `/dashboard`
+- `/vibes`
+- `/settings`
+- `/integrations`
+- `/profile/:id`
+
+## API Calls
+- REST requests to `http://localhost:8080/api/v1`
+
+## WebSocket
+- Real-time vibe detection via `ws://localhost:8081`
+
+## State Management
+- Redux Toolkit storing authentication and dashboard data
+
+## Core Components
+- Dashboard panels
+- Vibe radar
+- Settings forms
+
+## Dependencies
+- React 18
+- TypeScript 5
+- Redux Toolkit

--- a/frontend/web/README.md
+++ b/frontend/web/README.md
@@ -1,0 +1,21 @@
+# Web Frontend
+
+This React 18 + TypeScript 5 application delivers the main dashboards and settings interface for iVibe.
+
+## Component Structure
+- `src/main.tsx` – application entry point mounting the React tree.
+- `src/App.tsx` – defines routes for dashboard, vibes, settings, integrations, and profiles.
+- `src/components/` – reusable UI pieces such as dashboard panels, vibe radar, and forms.
+- `src/pages/` – page-level components mapped to routes.
+- `src/hooks/` – custom React hooks.
+- `src/services/` – REST clients targeting `http://localhost:8080/api/v1`.
+- `src/store/` – Redux Toolkit store handling auth and dashboard data.
+- `src/styles/` – global styles and theme configuration.
+- `src/types/` – shared TypeScript definitions.
+- `tests/` – placeholder for unit tests.
+
+## State Management
+Redux Toolkit provides slices for authentication and dashboard data. The store is configured under `src/store/` and supplied to components via the React provider.
+
+## API Integration
+All REST calls use the `src/services/` layer with the base URL `http://localhost:8080/api/v1`. Real-time vibe detection connects to `ws://localhost:8081`.


### PR DESCRIPTION
## Summary
- document web frontend architecture and dependencies
- explain component layout, state management, and API usage

## Testing
- `pnpm -C frontend/web test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689476a0002c832aad51cd8e29f566ee