### PR TITLE
docs: add database guidelines

### DIFF
--- a/database/AGENT.md
+++ b/database/AGENT.md
@@ -1,0 +1,29 @@
+# Database Guidelines
+
+This directory defines the PostgreSQL schema and data management strategy for iVibe. Changes here are **criticality 9** and must maintain stability and tenant isolation.
+
+## Tables
+- **events_raw** – TimescaleDB hypertable for raw capture events.
+- **embeddings** – pgvector table storing high‑dimensional embeddings.
+- **summaries** – generated activity summaries with associated vectors.
+- **users** – account, tier, and subscription metadata.
+- **vibe_scores** – derived vibe metrics per user.
+
+## Extensions
+- [TimescaleDB](https://www.timescale.com/) for time‑series storage and partitioning.
+- [pgvector](https://github.com/pgvector/pgvector) for similarity search on embeddings.
+
+## Partitioning
+- Partition **events_raw** by month and hash partitions on `user_id`.
+- Ensure new partitions exist ahead of time to avoid write amplification.
+
+## Security
+- Apply row‑level security policies on all user‑facing tables to enforce tenant isolation.
+
+## Materialized Views
+- `mv_time_by_language`
+- `mv_errors_fixed`
+- `mv_token_usage`
+
+## Retention
+- Enforce tier‑based data retention policies across raw and aggregated data.

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,21 @@
+# Database
+
+The iVibe platform uses PostgreSQL with the TimescaleDB and pgvector extensions. Raw events arrive in the `events_raw` hypertable and are rolled up into derived tables and materialized views for analytics and billing.
+
+## Architecture
+- **TimescaleDB** provides time‑series partitioning and compression.
+- **pgvector** powers semantic search on embeddings stored in the `embeddings` table.
+- Tables include `events_raw`, `embeddings`, `summaries`, `users`, and `vibe_scores`.
+- Materialized views such as `mv_time_by_language`, `mv_errors_fixed`, and `mv_token_usage` support dashboards and usage tracking.
+
+## Migration Strategy
+SQL migrations live in `migrations/` and are numbered sequentially. To apply them:
+
+1. Create a new migration file with the next numeric prefix.
+2. Execute migrations using `psql` or your preferred migration runner in ascending order.
+3. Avoid editing existing migrations; create follow‑up files for changes.
+
+## Backup Procedures
+- Perform nightly `pg_dump` of the entire database with compression.
+- Retain at least 30 days of dumps in secure object storage.
+- Test restore procedures regularly using staging environments.


### PR DESCRIPTION
## Summary
- document critical database tables, extensions, and retention policies
- outline database architecture, migration workflow, and backups

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_689476a6b6a8832ab9f4dd5686bebcfc