### PR TITLE
docs: add docker orchestration guides

### DIFF
--- a/infrastructure/docker/AGENT.md
+++ b/infrastructure/docker/AGENT.md
@@ -1,0 +1,35 @@
+# Docker Orchestration Instructions
+
+**Criticality:** 10
+
+This directory defines Docker Compose setups for all containerized services used by the platform.
+
+## Services
+| Service     | Port | Purpose                                 |
+|-------------|------|-----------------------------------------|
+| PostgreSQL  | 5432 | Primary database for application data   |
+| Redis       | 6379 | In-memory cache for fast lookups        |
+| Kafka       | 9092 | Event streaming backbone                |
+| MinIO       | 9000 | S3-compatible object storage            |
+| Keycloak    | 8080 | Identity and access management          |
+| Grafana     | 3000 | Metrics and dashboard visualisation     |
+
+## Networks
+- All services attach to a single bridge network for internal name resolution.
+- External access is only via ports explicitly published in the compose files.
+
+## Volumes
+- Persistent data is stored in named volumes such as `postgres-data`, `redis-data`, `kafka-data`, `minio-data`, and `grafana-data`.
+
+## Environment
+- Compose files load variables from `.env`. Copy `.env.example` to `.env` and adjust values before running.
+
+## Dependencies and Health Checks
+- Use `depends_on` with `condition: service_healthy` to orchestrate startup:
+  1. PostgreSQL
+  2. Redis
+  3. Kafka
+  4. MinIO
+  5. Keycloak (requires PostgreSQL)
+  6. Grafana (requires PostgreSQL and Keycloak)
+- Each service defines a health check (`pg_isready`, `redis-cli ping`, Kafka broker API check, `mc ls`, `curl -f http://keycloak:8080/health`, `curl -f http://grafana:3000/api/health`).

--- a/infrastructure/docker/README.md
+++ b/infrastructure/docker/README.md
@@ -1,0 +1,30 @@
+# Docker Deployment
+
+This directory contains Docker Compose configurations for local development and production deployments of the platform.
+
+## Architecture
+The stack comprises the following containers:
+
+- **PostgreSQL** – stores relational data.
+- **Redis** – provides caching.
+- **Kafka** – handles event streaming.
+- **MinIO** – stores binary objects.
+- **Keycloak** – manages authentication and authorisation.
+- **Grafana** – visualises metrics and logs.
+
+`docker-compose.yml` defines the baseline services, while `docker-compose.dev.yml` and `docker-compose.prod.yml` provide environment-specific overrides.
+
+## Networking
+All containers join a single bridge network, enabling name-based communication. Only the ports listed above are exposed to the host.
+
+## Deployment
+1. Copy `.env.example` to `.env` and adjust the values.
+2. Start the stack in development mode:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+   ```
+   For production:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+   ```
+3. Named volumes preserve data for stateful services across restarts.


### PR DESCRIPTION
## Summary
- document container services, networks, volumes, env config, and startup ordering in `infrastructure/docker/AGENT.md`
- add `infrastructure/docker/README.md` detailing architecture, networking, and deployment commands

## Testing
- `docker compose -f infrastructure/docker/docker-compose.yml config` *(fails: command not found)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689476c82854832a9da26c679c52261c