### PR TITLE
docs: add plugin guidelines

### DIFF
--- a/plugins/AGENT.md
+++ b/plugins/AGENT.md
@@ -1,0 +1,27 @@
+# Plugin Suite Guidelines
+
+These editor integrations carry a criticality rating of **8**, reflecting their role in reliably capturing developer activity across more than 100 editors.
+
+## Functionality
+- Record coding time, file modifications, and editor errors.
+- Operate transparently without capturing file contents unless configured.
+
+## Communication
+- Emit structured events to the local iVibe watcher when available.
+- Fallback to sending events directly to the configured API endpoint.
+
+## Installation
+- **VS Code** and **IntelliJ**: install from their official marketplaces.
+- **Neovim** and **Sublime Text**: install manually as described in each plugin's README.
+
+## Configuration
+- Set an API key and event endpoint.
+- Adjust privacy options such as excluding directories or error details.
+- Configuration is stored locally per editor.
+
+## Languages
+- `vscode/` – TypeScript
+- `intellij/` – Kotlin
+- `neovim/` – Lua
+- `sublime/` – Python
+

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,34 @@
+# iVibe Editor Plugins
+
+Official iVibe plugins bring activity tracking to over 100 editors. This directory currently hosts first‑party integrations for:
+
+- **VS Code**
+- **IntelliJ IDEA**
+- **Neovim**
+- **Sublime Text**
+
+## Installation
+
+### VS Code
+1. Open the Extensions view (`Ctrl+Shift+X`).
+2. Search for `iVibe` and install the extension from the Marketplace.
+3. Configure your API key and endpoint in the extension settings.
+
+### IntelliJ IDEA
+1. Go to **Settings → Plugins**.
+2. Search for `iVibe` in the JetBrains Marketplace and install.
+3. Restart the IDE and enter your API key in **Tools → iVibe**.
+
+### Neovim
+1. Install manually or via a plugin manager:
+   ```lua
+   use { 'ivibe/ivibe-live', rtp = 'plugins/neovim' }
+   ```
+2. Run `:lua require('ivibe').setup{ api_key = 'YOUR_KEY', endpoint = 'https://localhost:5600' }`.
+
+### Sublime Text
+1. Copy `ivibe.py` into your `Packages` directory or add the repository to Package Control.
+2. Set your API key and endpoint in `Preferences → Package Settings → iVibe`.
+
+For advanced configuration and troubleshooting, see the README in each plugin's subdirectory.
+


### PR DESCRIPTION
## Summary
- document plugin suite functionality and configuration in `plugins/AGENT.md`
- add `plugins/README.md` covering supported editors and installation steps

## Testing
- `npm test` (vscode plugin, no test script)
- `gradle test` (intellij plugin, no test task)
- `python -m py_compile ivibe.py`
- `lua -p lua/ivibe/init.lua` (lua not installed)


------
https://chatgpt.com/codex/tasks/task_e_689476fe2428832a8c2c1c7fae2720be