### PR TITLE
docs: add issue template guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/AGENT.md
+++ b/.github/ISSUE_TEMPLATE/AGENT.md
@@ -1,0 +1,9 @@
+# Issue Template Agent
+- **Criticality:** 5/10
+- **Purpose:** Standardized issue reporting templates
+- **Files:**
+  - `bug_report.md` (criticality: 5)
+  - `feature_request.md` (criticality: 5)
+  - `security_vulnerability.md` (criticality: 10)
+- **Communication:** User input → GitHub Issues → Development team
+- **Data flow:** Structured markdown → Issue tracking → Project boards

--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,0 +1,9 @@
+# Issue Templates
+
+This folder contains GitHub issue templates that guide contributors to provide the information we need.
+
+- **bug_report.md** – prompts for context, steps to reproduce, and expected versus actual results so bugs can be investigated efficiently.
+- **feature_request.md** – asks for the problem to be solved and proposed solutions, helping the team evaluate new ideas.
+- **security_vulnerability.md** – collects details about potential security issues. Please also report security concerns directly to [security@ivibe.live](mailto:security@ivibe.live).
+
+These templates ensure submissions follow a consistent format, allowing issues to move from user reports to project boards without friction.


### PR DESCRIPTION
## Summary
- add AGENT instructions for issue templates
- document bug, feature, and security reporting, with security contact

## Testing
- `pytest`
- `npm test` (fails: Could not read package.json)
- `cargo test` (fails: could not find `Cargo.toml`)


------
https://chatgpt.com/codex/tasks/task_e_689479818db4832aa2439e3e0ed65d21