### PR TITLE
docs: add vectorizer service docs

### DIFF
--- a/backend/services/vectorizer-service/AGENT.md
+++ b/backend/services/vectorizer-service/AGENT.md
@@ -1,0 +1,10 @@
+# Vectorizer Service AGENT
+
+- **Criticality:** 9/10
+- **Purpose:** Text and audio embedding generation
+- **Files:** `src/main.rs`, `src/kafka_consumer.rs`, `src/openai/client.rs`, `src/openai/embeddings.rs`, `src/local_models/fallback.rs`, `src/storage.rs`
+- **Consumes:** Kafka `events_raw` topic
+- **API:** OpenAI `text-embedding-3-small` via Helicone proxy
+- **Fallback:** Local model for offline mode
+- **Stores:** PostgreSQL `pgvector` `embeddings` table
+- **Dimensions:** 1536-dimensional vectors

--- a/backend/services/vectorizer-service/README.md
+++ b/backend/services/vectorizer-service/README.md
@@ -1,0 +1,32 @@
+# Vectorizer Service
+
+The vectorizer service consumes events from Kafka and turns textual or audio content into high‑dimensional embeddings.
+
+## Embedding Models
+
+- **Primary:** OpenAI `text-embedding-3-small` (1536 dimensions).
+- **Fallback:** Local model used when external APIs are unavailable.
+
+## Helicone Proxy Setup
+
+All OpenAI requests pass through the Helicone proxy. Configure the following environment variables:
+
+```bash
+export HELICONE_API_BASE="https://oai.helicone.ai/v1"
+export OPENAI_API_KEY="sk-..."
+```
+
+The service sends embedding requests to `text-embedding-3-small` through this proxy to capture usage metrics and provide centralized access control.
+
+## Vector Similarity Search
+
+Embeddings are stored in a PostgreSQL table with a `pgvector` column. Example query for nearest neighbors:
+
+```sql
+SELECT id, payload
+FROM embeddings
+ORDER BY embedding <-> $1
+LIMIT 5;
+```
+
+This enables semantic search over previously ingested events.


### PR DESCRIPTION
## Summary
- document vectorizer service responsibilities, dependencies, and storage details in AGENT.md
- add README covering embedding models, Helicone proxy usage, and vector search

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68947afa0870832a96baa5aff878ee8a