### PR TITLE
docs: document audio watcher privacy and vectorization

### DIFF
--- a/backend/watchers/aw-watcher-audio/AGENT.md
+++ b/backend/watchers/aw-watcher-audio/AGENT.md
@@ -1,0 +1,7 @@
+- **Criticality:** 8/10
+- **Purpose:** Audio capture and privacy-preserving vectorization
+- **Files:** src/main.rs, src/capture.rs, src/hotword.rs, src/vectorizer.rs, src/privacy.rs
+- **Triggers:** Hot-word detection, context changes, manual activation
+- **Privacy:** Audio converted to embeddings on-device, raw audio discarded
+- **Storage:** Only embeddings stored in PostgreSQL pgvector
+- **Audio format:** 16kHz mono for efficient processing

--- a/backend/watchers/aw-watcher-audio/README.md
+++ b/backend/watchers/aw-watcher-audio/README.md
@@ -1,0 +1,26 @@
+# aw-watcher-audio
+
+`aw-watcher-audio` captures short snippets from the microphone and turns them into privacy-preserving embeddings. The watcher only runs when activated by a hot word, a change in application context, or manual user action.
+
+## Privacy
+
+- Audio is recorded as **16kHz mono** for efficient processing.
+- Samples are converted to vector embeddings on the device and the raw audio is discarded immediately.
+- Only embeddings are stored in PostgreSQL using the `pgvector` extension.
+
+## Vectorization Process
+
+1. Detect trigger and capture a short audio segment.
+2. Normalize and resample to 16kHz mono if necessary.
+3. Generate an embedding for the audio segment.
+4. Send the embedding to the server for storage and similarity search.
+
+## Hot-word Configuration
+
+The watcher listens for a configurable hot word that activates audio capture. Set the desired phrase and sensitivity in the configuration file or environment variables. When the phrase is spoken, the watcher records the following few seconds for vectorization.
+
+## Triggers
+
+- Hot-word detection
+- Context changes (e.g., active application or project)
+- Manual activation through the CLI


### PR DESCRIPTION
## Summary
- add AGENT instructions for aw-watcher-audio
- document privacy, vectorization, and hot-word settings in README

## Testing
- `cargo test -p aw-watcher-audio`


------
https://chatgpt.com/codex/tasks/task_e_68947ae21fb0832aa54dd6bcf8d75834