### PR TITLE
docs: add backend workspace docs

### DIFF
--- a/backend/AGENT.md
+++ b/backend/AGENT.md
@@ -1,0 +1,12 @@
+# Backend
+
+- **Criticality:** 10/10
+- **Purpose:** Core Rust backend services and watchers
+- **Files:**
+  - `Cargo.toml` (criticality: 10) - workspace configuration
+  - `Cargo.lock` (criticality: 10) - locked dependencies
+  - `deny.toml` (criticality: 9) - security policy
+- **Subdirectories:** `watchers/`, `services/`, `intelligence/`, `api/`, `cli/`, `shared/`
+- **Communication:** All backend components use gRPC internally, REST/GraphQL externally
+- **Workspace members:** 19 crates total
+- **Build:** `cargo build --locked` for supply chain security

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,38 @@
+# Backend Workspace
+
+This directory hosts the Rust monorepo containing all backend services for the platform. Components communicate with gRPC internally and expose REST or GraphQL interfaces externally.
+
+## Workspace Structure
+
+- `watchers/` – data capture clients
+- `services/` – core backend services
+- `intelligence/` – analytics and AI jobs
+- `api/` – public and internal APIs
+- `cli/` – command‑line tools
+- `shared/` – common libraries and utilities
+
+## Building
+
+Build all crates with locked dependencies to ensure supply‑chain integrity:
+
+```sh
+cargo build --locked
+```
+
+## Testing
+
+Run the full test suite:
+
+```sh
+cargo test
+```
+
+## Security
+
+Audit and check dependencies regularly:
+
+```sh
+cargo audit
+cargo deny check
+```
+


### PR DESCRIPTION
## Summary
- document backend workspace layout and build details
- add AGENT guidelines for critical backend files

## Testing
- `cargo build --locked`
- `cargo test`
- `cargo audit` *(fails: no such command)*
- `cargo install cargo-audit` *(fails: failed to download from crates.io: 403)*
- `cargo deny check` *(fails: no such command)*
- `cargo install cargo-deny` *(fails: failed to download from crates.io: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68947a166174832a9d36bd76db6a4d74