### PR TITLE
docs: add GitLab CI guidance

### DIFF
--- a/.gitlab/ci/AGENT.md
+++ b/.gitlab/ci/AGENT.md
@@ -1,0 +1,13 @@
+# GitLab CI Agent
+
+- **Criticality:** 7/10
+- **Purpose:** GitLab CI/CD pipeline configuration (alternative to GitHub Actions)
+- **Files:**
+  - `.gitlab-ci.yml` – criticality: 8
+- **Subdirectories:**
+  - `jobs/` – test, build, deploy, security configs
+  - `scripts/` – `cargo-audit.sh`, `npm-audit.sh`
+- **Communication:** GitLab runners on Arch Linux
+- **Triggers:** Push events, merge requests, scheduled pipelines
+- **Integration:** HashiCorp Vault for secrets, Docker Registry for images
+

--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -1,0 +1,8 @@
+# GitLab CI
+
+This directory contains templates and helper scripts for running the project on GitLab CI/CD. It is intended for teams that prefer GitLab while maintaining parity with the GitHub Actions setup.
+
+Pipelines execute on runners using Arch Linux so the build and test environment matches the developers' machines. The root `.gitlab-ci.yml` file references job definitions in `jobs/` and uses utility scripts in `scripts/` for tasks such as dependency audits.
+
+Secrets are pulled from HashiCorp Vault and container images are published to a Docker Registry.
+


### PR DESCRIPTION
## Summary
- document GitLab CI configuration and runner details
- describe templates and scripts used for GitLab pipelines

## Testing
- `npm test` *(fails: could not read package.json)*
- `cargo test` *(fails: could not find Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68947a10c1e4832a833b295ba0106fee