### PR TITLE
docs: add intelligence module instructions

### DIFF
--- a/backend/intelligence/AGENT.md
+++ b/backend/intelligence/AGENT.md
@@ -1,0 +1,19 @@
+# Intelligence Module Agent Instructions
+
+Criticality: 10
+
+## Emotion Detection
+Camera → Face detection → Classification → Context capture
+
+## Vibe Social Engine
+BLE/WiFi scan → Score calculation (1-1000) → Request handling
+
+## Models
+- TFLite for mobile
+- WASM for web
+
+## Privacy
+On-device processing, only vectors transmitted
+
+## Communication
+gRPC to Event Gateway

--- a/backend/intelligence/README.md
+++ b/backend/intelligence/README.md
@@ -1,0 +1,16 @@
+# Intelligence Engines
+
+This directory hosts the AI and social intelligence engines that power emotion detection and vibe scoring.
+
+## Emotion Detection
+Camera frames pass through a face detector before classification into emotion vectors. Context modules capture surrounding state for each frame. Mobile builds use TensorFlow Lite models while web builds rely on WebAssembly.
+
+## Vibe Social Engine
+Devices periodically scan for nearby BLE and WiFi signals. The proximity features feed a compatibility algorithm that outputs a vibe score between 1 and 1000. Scores drive request handling and subsequent social interactions.
+
+## Models
+- **Mobile:** TensorFlow Lite models optimised for edge devices.
+- **Web:** WebAssembly modules loaded for in-browser inference.
+
+## Privacy Architecture
+Processing remains on-device. Only high-level vectors or scores are transmitted, never raw images or identifiers. Communication with the broader platform occurs through gRPC calls to the Event Gateway.


### PR DESCRIPTION
## Summary
- document emotion detection and vibe scoring flows
- outline model targets, privacy rules, and gRPC communication
- add README describing ML models, scoring algorithm, and privacy architecture

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6894770f45ec832ab38b7e66ae0cbc81