### PR TITLE
docs: add issue template agent and readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/AGENT.md
+++ b/.github/ISSUE_TEMPLATE/AGENT.md
@@ -1,0 +1,10 @@
+# Issue Template Agent
+
+- **Criticality:** 5/10
+- **Purpose:** Standardized issue reporting templates
+- **Files:**
+  - `bug_report.md` (criticality: 5)
+  - `feature_request.md` (criticality: 5)
+  - `security_vulnerability.md` (criticality: 10)
+- **Communication:** User input → GitHub Issues → Development team
+- **Data flow:** Structured markdown → Issue tracking → Project boards

--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,0 +1,9 @@
+# Issue Templates
+
+This directory contains templates that guide users in reporting bugs, requesting new features, and disclosing security vulnerabilities.
+
+- **bug_report.md** – prompts users to outline the problem, helping the team reproduce and fix bugs efficiently.
+- **feature_request.md** – asks for details about desired functionality and motivations, enabling thoughtful feature planning.
+- **security_vulnerability.md** – provides a structured way to describe potential security issues. For sensitive matters, also report them directly to [security@ivibe.live](mailto:security@ivibe.live).
+
+Using these templates ensures that issues include the information needed to triage tasks and track progress on project boards.


### PR DESCRIPTION
## Summary
- document issue template roles and criticalities
- add README explaining how to use issue templates

## Testing
- `npm test` (fails: could not read package.json)
- `cargo test` (fails: could not find Cargo.toml)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894796dea88832a95b74cc75eb25801