### PR TITLE
docs: document API services

### DIFF
--- a/backend/api/AGENT.md
+++ b/backend/api/AGENT.md
@@ -1,0 +1,29 @@
+# API Service Agent Instructions
+
+**Criticality**: 10
+
+## REST API
+- Framework: [Actix-web](https://actix.rs)
+- Port: **8080**
+- All endpoints require a valid JWT in the `Authorization` header.
+
+## GraphQL API
+- Framework: [async-graphql](https://async-graphql.github.io/async-graphql/)
+- Port: **8082**
+
+## WebSocket
+- Port: **8081**
+- Used for real-time updates.
+
+## Middleware
+- JWT authentication validation
+- Subscription tier enforcement
+- Rate limiting
+
+## Routes
+- `GET /api/v1/events`
+- `GET /api/v1/dashboard`
+- `GET /api/v1/vibe`
+
+## Caching
+- Redis-backed caching for dashboard queries with a 60-second TTL

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -1,0 +1,18 @@
+# API Services
+
+This directory contains the API layer for iVibe, exposing both REST and GraphQL interfaces to clients.
+
+## Design
+- **REST**: Implemented with Actix-web on port `8080`. Routes are organised under `src/routes`.
+- **GraphQL**: Implemented with async-graphql on port `8082` using a schema defined in `graphql-api/src/schema.rs`.
+- **WebSocket**: Real-time updates are served on port `8081`.
+- **Caching**: Dashboard queries leverage Redis with a 60-second TTL.
+
+## Authentication
+All APIs require JWT authentication. Clients must supply a valid token in the `Authorization: Bearer <token>` header. Middleware enforces subscription tier limits and rate limiting.
+
+## Client Libraries
+- **Rust**: Use [`reqwest`](https://docs.rs/reqwest/) or [`async-graphql`](https://async-graphql.github.io/async-graphql/en/client/overview.html) for network calls.
+- **TypeScript**: Use [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for REST and [`graphql-request`](https://github.com/jasonkuhrt/graphql-request) for GraphQL queries.
+
+Refer to the `rest-api/` and `graphql-api/` directories for implementation details.


### PR DESCRIPTION
## Summary
- add AGENT instructions for API services
- outline API design and client guidance in README

## Testing
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_689477155634832a9df41955d0090964