### PR TITLE
docs: add KDevelop watcher agent and README

### DIFF
--- a/backend/watchers/aw-watcher-kdevelop/AGENT.md
+++ b/backend/watchers/aw-watcher-kdevelop/AGENT.md
@@ -1,0 +1,7 @@
+- Criticality: 10/10
+- Purpose: KDevelop IDE integration for developer activity tracking
+- Files: src/main.rs, src/plugin.rs (KTextEditor integration), src/dbus.rs (DBus communication), src/events.rs
+- Monitors: File open/save, compile events, debug sessions, project switches
+- Communication: KTextEditor API → DBus → Rust watcher → Event Gateway
+- Event data: Project name, branch, language, file path, compilation status
+- Integration: Built on KTextEditor plugin framework

--- a/backend/watchers/aw-watcher-kdevelop/README.md
+++ b/backend/watchers/aw-watcher-kdevelop/README.md
@@ -1,0 +1,23 @@
+# aw-watcher-kdevelop
+
+A watcher that hooks into KDevelop to record editor activity for ActivityWatch. It registers as a KTextEditor plugin and sends structured events through DBus to the ActivityWatch event gateway.
+
+## Installation
+
+1. Build the watcher:
+   ```bash
+   cargo build --release
+   ```
+2. Copy the produced plugin library from `target/release` into your KDevelop plugin directory (usually `~/.local/share/kdevelop/plugins`).
+3. Start KDevelop and enable the **ActivityWatch KDevelop** plugin.
+4. Run the watcher binary to forward events to your ActivityWatch backend.
+
+## Captured Metrics
+
+- File open and save operations
+- Project and branch switches
+- Compilation results
+- Debug session start and stop
+- Detected programming language and file path
+
+These metrics provide detailed insight into developer workflow inside KDevelop and are forwarded to the ActivityWatch event gateway for aggregation and analysis.


### PR DESCRIPTION
## Summary
- document KDevelop watcher components and event flow
- add README with installation steps and metrics

## Testing
- `cargo test -p aw-watcher-kdevelop`


------
https://chatgpt.com/codex/tasks/task_e_68947acd85d4832a8548d523f7ba58be