### PR TITLE
docs: add Stripe webhook handler instructions

### DIFF
--- a/backend/services/stripe-webhook-handler/AGENT.md
+++ b/backend/services/stripe-webhook-handler/AGENT.md
@@ -1,0 +1,14 @@
+# AGENT Instructions
+
+- Criticality: 9/10
+- Purpose: Subscription management and billing
+- Files:
+  - src/main.rs
+  - src/webhook.rs
+  - src/events/subscription.rs
+  - src/events/invoice.rs
+  - src/database.rs
+- Webhook events: subscription.created, subscription.updated, invoice.paid
+- Updates: users.tier, subscription_id, seats
+- Signature verification: Stripe webhook secret
+- Tier enforcement: Adjusts retention_days, integration_limits

--- a/backend/services/stripe-webhook-handler/README.md
+++ b/backend/services/stripe-webhook-handler/README.md
@@ -1,0 +1,17 @@
+# Stripe Webhook Handler
+
+## Overview
+This service processes Stripe webhook events to manage subscription tiers and billing state. It listens for subscription and invoice events and updates user records accordingly.
+
+## Setup
+1. Create a webhook endpoint in the Stripe dashboard and point it at the handler's `/webhook` route.
+2. Retrieve the webhook signing secret and expose it to the service via the `STRIPE_WEBHOOK_SECRET` environment variable.
+3. Deploy the service and ensure Stripe can reach it over HTTPS. The handler verifies each request using the secret before processing events.
+
+## Subscription Tier Logic
+- Supported events: `subscription.created`, `subscription.updated`, and `invoice.paid`.
+- On subscription creation or update, the handler updates `users.tier` and `users.subscription_id` and adjusts retention days and integration limits based on the subscribed tier.
+- When an invoice is paid, the handler confirms the subscription is active and records the seat count.
+
+## Seat Counting for Team Plans
+Team and Business plans are billed per seat. The webhook extracts the subscription quantity and stores it in `users.seats`. This count is used for reconciliation and enforcement of per-seat limits.


### PR DESCRIPTION
## Summary
- document internal instructions for Stripe webhook handler service
- add README covering webhook setup, subscription tier logic, and seat tracking

## Testing
- `cargo test -p stripe-webhook-handler --locked`


------
https://chatgpt.com/codex/tasks/task_e_68947b1101a4832a89071e2873c8e48a