### PR TITLE
docs: document intelligence layer

### DIFF
--- a/backend/intelligence/AGENT.md
+++ b/backend/intelligence/AGENT.md
@@ -1,0 +1,11 @@
+# Intelligence Layer Agent
+
+- **Criticality:** 10/10
+- **Purpose:** AI and social intelligence engines
+- **Subdirectories:**
+  - emotion-detection (criticality: 9)
+  - vibe-social-engine (criticality: 10)
+- **Technologies:** Rust + WASM for edge inference
+- **Communication:** Both services → Event Gateway via gRPC
+- **Privacy:** On-device processing for emotions and audio
+

--- a/backend/intelligence/README.md
+++ b/backend/intelligence/README.md
@@ -1,0 +1,11 @@
+# Intelligence Layer
+
+The intelligence layer powers emotion detection and proximity‑based social features within the iVibe platform.
+
+It comprises two Rust services compiled to WebAssembly for edge deployment:
+
+- **Emotion Detection** – analyses on-device audio to infer emotional state while preserving privacy.
+- **Vibe Social Engine** – uses nearby signals and shared contexts to suggest connections and interactions.
+
+Both services communicate with the rest of the system through the Event Gateway using gRPC, enabling real-time insights without sending raw audio off-device.
+


### PR DESCRIPTION
## Summary
- add AGENT instructions detailing intelligence module criticality and privacy
- document emotion detection and proximity-based social features

## Testing
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_e_68947b158534832ab509d9e99c653806