### PR TITLE
docs: add REST API agent and README

### DIFF
--- a/backend/api/rest-api/AGENT.md
+++ b/backend/api/rest-api/AGENT.md
@@ -1,0 +1,21 @@
+# REST API Agent Instructions
+
+- **Criticality:** 10/10
+- **Purpose:** RESTful API server
+- **Framework:** Actix-web
+- **Files:**
+  - `src/main.rs`
+  - `src/routes/events.rs`
+  - `src/routes/dashboard.rs`
+  - `src/routes/vibe.rs`
+  - `src/routes/export.rs`
+  - `src/routes/integrations.rs`
+  - `src/middleware/auth.rs`
+  - `src/middleware/tier.rs`
+- **Endpoints:**
+  - `/api/events`
+  - `/api/dashboard`
+  - `/api/vibe/nearby`
+  - `/api/export`
+- **Caching:** 60-second dashboard cache
+- **Export formats:** CSV, JSON, PDF

--- a/backend/api/rest-api/README.md
+++ b/backend/api/rest-api/README.md
@@ -1,0 +1,52 @@
+# REST API
+
+Actix-web powered RESTful API server for the iVibe platform.
+
+## OpenAPI
+
+```yaml
+openapi: 3.0.0
+info:
+  title: iVibe REST API
+  version: 1.0.0
+paths:
+  /api/events:
+    get:
+      summary: List recent events
+  /api/dashboard:
+    get:
+      summary: Retrieve dashboard metrics (cached for 60 seconds)
+  /api/vibe/nearby:
+    get:
+      summary: Fetch nearby vibe scores
+  /api/export:
+    post:
+      summary: Export activity data in CSV, JSON, or PDF formats
+```
+
+## Example Requests
+
+```bash
+# List events
+curl http://localhost:8000/api/events
+
+# Retrieve dashboard (cached for 60 seconds)
+curl http://localhost:8000/api/dashboard
+
+# Vibe nearby
+curl "http://localhost:8000/api/vibe/nearby?lat=51.5&lng=-0.1"
+
+# Export data as CSV
+curl -X POST "http://localhost:8000/api/export?format=csv"
+```
+
+## Tier-Based Feature Availability
+
+| Endpoint | Free | Pro | Business |
+|----------|:----:|:---:|:--------:|
+| `/api/events` | ✅ | ✅ | ✅ |
+| `/api/dashboard` | ✅ | ✅ | ✅ |
+| `/api/vibe/nearby` | ✅ | ✅ | ✅ |
+| `/api/export` | ❌ | CSV & JSON | CSV, JSON & PDF |
+
+`/api/export` is available only to paid tiers. The Business tier additionally enables PDF export.


### PR DESCRIPTION
## Summary
- add AGENT instructions for REST API endpoints, caching, and export formats
- document OpenAPI spec, example requests, and tier-based availability in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68947b2d7180832a8487996859813156