### PR TITLE
docs: add GraphQL API agent and README

### DIFF
--- a/backend/api/graphql-api/AGENT.md
+++ b/backend/api/graphql-api/AGENT.md
@@ -1,0 +1,9 @@
+# GraphQL API Agent
+
+- **Criticality:** 9/10
+- **Purpose:** GraphQL API for complex queries
+- **Files:** `src/main.rs`, `src/schema.rs`, `src/context.rs`, `src/resolvers/`
+- **Framework:** async-graphql
+- **Schema:** User, Event, Dashboard, Vibe types
+- **Subscriptions:** Real-time vibe updates via WebSocket
+- **DataLoader:** N+1 query optimization

--- a/backend/api/graphql-api/README.md
+++ b/backend/api/graphql-api/README.md
@@ -1,0 +1,72 @@
+# GraphQL API
+
+This crate exposes a GraphQL API for complex queries using `async-graphql`.
+
+## Schema
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  events: [Event!]!
+}
+
+type Event {
+  id: ID!
+  userId: ID!
+  timestamp: DateTime!
+  description: String
+}
+
+type Dashboard {
+  id: ID!
+  ownerId: ID!
+  vibes: [Vibe!]!
+}
+
+type Vibe {
+  id: ID!
+  score: Int!
+  message: String
+}
+
+type Query {
+  user(id: ID!): User
+  events(userId: ID!): [Event!]!
+}
+
+type Subscription {
+  vibeUpdated(userId: ID!): Vibe
+}
+```
+
+## Example Query
+
+```graphql
+query GetUserWithEvents($id: ID!) {
+  user(id: $id) {
+    id
+    name
+    events {
+      id
+      timestamp
+      description
+    }
+  }
+}
+```
+
+## Subscription Setup
+
+Connect to the WebSocket endpoint and run:
+
+```graphql
+subscription OnVibeUpdated($userId: ID!) {
+  vibeUpdated(userId: $userId) {
+    score
+    message
+  }
+}
+```
+
+The server pushes real-time vibe updates to connected clients.


### PR DESCRIPTION
## Summary
- add agent info for GraphQL API
- document schema, example queries, and subscriptions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68947b3405f0832a8299217318a0e91f