### PR TITLE
docs: add backend API guidelines

### DIFF
--- a/backend/api/AGENT.md
+++ b/backend/api/AGENT.md
@@ -1,0 +1,11 @@
+- **Criticality**: 10/10
+- **Purpose**: External API interfaces
+- **Subdirectories**:
+  - `rest-api` (criticality: 10)
+  - `graphql-api` (criticality: 9)
+- **Protocols**:
+  - REST on port 8080
+  - GraphQL on port 8082
+- **Authentication**: JWT via Keycloak
+- **Rate limiting**: Per-tier quotas
+- **Middleware**: CORS, compression, auth, tier enforcement

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -1,0 +1,37 @@
+# API Interfaces
+
+This directory hosts the public APIs for iVibe.
+
+## REST API
+
+Runs on **port 8080** and exposes HTTP endpoints:
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET /events` / `POST /events` | Manage activity events |
+| `GET /dashboard` | Retrieve dashboard metrics |
+| `POST /integrations` | Configure third‑party integrations |
+| `GET /vibe` | Access vibe scores |
+| `GET /export` | Export data snapshots |
+
+## GraphQL API
+
+Serves on **port 8082** with a single `/graphql` endpoint that provides equivalent access to the REST resources via queries and mutations.
+
+## Authentication
+
+1. Obtain a JWT access token from **Keycloak** via the OpenID Connect token endpoint.
+2. Include the token in requests using `Authorization: Bearer <token>`.
+3. Middleware validates the signature, checks claims, applies CORS and compression, and enforces subscription tier quotas.
+
+## Rate Limits
+
+| Tier | Requests per minute |
+| ---- | ------------------ |
+| Free | 60 |
+| Basic | 120 |
+| Pro | 600 |
+| Team | 1200 |
+| Business | 6000 |
+
+Limits apply across both REST and GraphQL endpoints. Exceeding the quota returns HTTP **429 Too Many Requests**.


### PR DESCRIPTION
## Summary
- document backend API interfaces in new AGENT.md
- add README covering endpoints, auth flow, and rate limits

## Testing
- `cargo test -p rest-api -p graphql-api`


------
https://chatgpt.com/codex/tasks/task_e_68947b27fd74832a8d19f63c0dcc96b8