### PR TITLE
docs: add directory guide and agent

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1,0 +1,27 @@
+# Documentation Agent Instructions
+
+This directory contains reference materials for the iVibe platform. When working on files under `/docs`, follow these guidelines.
+
+## Architecture
+- Use the four-plane model (control, data, compute, presentation) to explain the system.
+- Document how components interact across planes and keep diagrams consistent with the implementation.
+
+## API Specifications
+- REST APIs are defined using **OpenAPI 3.0** in `api/rest/openapi.yaml`.
+- GraphQL operations are defined in `api/graphql/schema.graphql`.
+- Update these specs whenever endpoints or schema change.
+
+## Guides
+- Guides in `guides/` must provide step-by-step setup instructions with prerequisites and expected results.
+- Verify each step before publishing.
+
+## Security
+- Describe the threat model, security controls, and audit procedures for the platform.
+- Note authentication, authorisation, encryption, and logging requirements.
+
+## Privacy
+- Explain data handling practices and how GDPR compliance is achieved.
+- Include policies on collection, storage, retention, and user consent.
+
+## Updates
+- Keep documentation in sync with code changes. Update relevant files and specs in the same commit as code modifications.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,25 @@
-# placeholder
+# iVibe Documentation
+
+This directory provides technical references and guides for the iVibe platform. The documents below help you understand the system architecture, develop features, deploy services, and integrate with external tools.
+
+## Core References
+- [ARCHITECTURE.md](ARCHITECTURE.md) – four-plane design and component communication.
+- [DEVELOPMENT.md](DEVELOPMENT.md) – local development setup and workflows.
+- [DEPLOYMENT.md](DEPLOYMENT.md) – production and staging deployment procedures.
+- [SECURITY.md](SECURITY.md) – threat model, controls, and auditing.
+- [PRIVACY.md](PRIVACY.md) – data handling and GDPR compliance policies.
+
+## API Specifications
+- [API.md](API.md) – overview of available APIs.
+- REST specification: [`api/rest/openapi.yaml`](api/rest/openapi.yaml)
+- GraphQL schema: [`api/graphql/schema.graphql`](api/graphql/schema.graphql)
+
+## Guides
+Step-by-step tutorials are available in the [`guides/`](guides) directory:
+- [Quick Start](guides/quick-start.md)
+- [Grafana Setup](guides/grafana-setup.md)
+- [Stripe Setup](guides/stripe-setup.md)
+- [Integrations](guides/integrations.md)
+
+## Keeping Docs Updated
+Always update relevant documentation alongside code changes to ensure the information here remains current.


### PR DESCRIPTION
## Summary
- add doc-level agent instructions covering architecture, APIs, guides, security, privacy, and update expectations
- expand docs README with navigation to core references, API specs, and setup guides

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689476e93780832ab9c19a62799de48b