### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,2 +1,38 @@
 version: 2
-updates: []
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/sdk/rust"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend/web"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend/desktop"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend/browser-extension"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/sdk/typescript"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/plugins/vscode"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/mobile/android"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- set up Dependabot for GitHub Actions, Rust workspaces, TypeScript packages, Android app, and VS Code extension

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6894f83daf00832aa93bd75e4fc801c5