### PR TITLE
docs: document summarizer job source

### DIFF
--- a/backend/services/summarizer-job/src/AGENTS.md
+++ b/backend/services/summarizer-job/src/AGENTS.md
@@ -1,0 +1,13 @@
+# Summarizer Job Source Instructions
+
+This directory houses the AI summarization service.
+
+## Operational Guidelines
+- Run via cron daily at **04:00 UTC**.
+- For each project, fetch events from the preceding **24 hours**.
+- For **Pro tier and above**, invoke the OpenAI **GPT-4o** model through the **Helicone** proxy.
+  - Record token usage and cost data returned by Helicone for tracking.
+- Build a markdown digest summarising fetched events.
+- Generate embeddings for the digest and store both summary and embedding in the `summaries` table.
+- Apply tier checks: tiers below Pro skip remote GPT-4o calls.
+- Refer to `/AGENTS.md` under **SummariserJob** for schema and specification details.

--- a/backend/services/summarizer-job/src/README.md
+++ b/backend/services/summarizer-job/src/README.md
@@ -1,0 +1,16 @@
+# Summarizer Job Source
+
+This folder implements the AI summarization service responsible for generating daily project digests.
+
+## Contents
+- `openai/`
+  - `gpt4o.rs`
+  - `mod.rs`
+- `main.rs` – entry point for the job (**criticality: 10**)
+- `scheduler.rs` – cron scheduling (**criticality: 9**)
+- `summary_builder.rs` – digest creation and embeddings (**criticality: 9**)
+- `tier_check.rs` – Pro+ tier validation (**criticality: 9**)
+
+The service retrieves the last 24 hours of events per project and, for Pro or higher tiers, sends them to the GPT‑4o model via the Helicone proxy. The resulting markdown summary and its embeddings are stored in the database.
+
+See `AGENTS.md` for operational guidelines.


### PR DESCRIPTION
## Summary
- add AGENTS guidelines for summarizer job source directory
- describe summarizer job structure and critical files in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68950776eca8832aba690cec40aa1e21