### PR TITLE
docs: document kdevelop watcher source

### DIFF
--- a/backend/watchers/aw-watcher-kdevelop/src/AGENT.md
+++ b/backend/watchers/aw-watcher-kdevelop/src/AGENT.md
@@ -1,0 +1,8 @@
+- Criticality: 10/10
+- Scope: Implementation files for the KDevelop watcher.
+- Responsibilities:
+  - Register the watcher as a KDevelop/KTextEditor plugin.
+  - Monitor KTextEditor DBus signals for file open, save, compile and debug events.
+  - Extract project, branch and language metadata for each captured event.
+  - Stream structured events to the ActivityWatch event gateway.
+  - Ensure emitted records conform to the platform EventSchema (event_id, user_id, timestamp, source=`"kdevelop"`, project, language, payload).

--- a/backend/watchers/aw-watcher-kdevelop/src/README.md
+++ b/backend/watchers/aw-watcher-kdevelop/src/README.md
@@ -1,0 +1,14 @@
+# aw-watcher-kdevelop/src
+
+This directory hosts the source code for the KDevelop IDE watcher. It implements the KTextEditor plug-in that captures editor activity and forwards structured events to the ActivityWatch event gateway.
+
+## Files
+
+| File      | Criticality | Description |
+|-----------|-------------|-------------|
+| `main.rs` | 10/10 | Entry point that initialises DBus listeners and launches the watcher. |
+| `plugin.rs` | 10/10 | Registers the watcher as a KDevelop/KTextEditor plug-in and hooks editor callbacks. |
+| `dbus.rs` | 9/10 | Handles DBus communication with KDevelop to receive KTextEditor signals. |
+| `events.rs` | 8/10 | Defines event structures and helper functions for sending records to the gateway. |
+
+These modules collectively provide IDE integration, monitoring file open/save, compile, and debug events while attaching project, branch, and language metadata as required by the platform's EventSchema.


### PR DESCRIPTION
## Summary
- document KDevelop watcher source layout and responsibilities
- describe DBus monitoring and EventSchema compliance

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895070504ac832aa1a5deaf02d4a05c