### PR TITLE
docs: add deployment automation guidelines

### DIFF
--- a/scripts/deploy/AGENT.md
+++ b/scripts/deploy/AGENT.md
@@ -1,0 +1,22 @@
+# Deployment Automation Guidelines
+
+- **Criticality:** 9/10
+- **Purpose:** Automate production deployments for iVibe.live.
+
+## Files
+- `deploy-prod.sh` – orchestrates blue‑green deployments (criticality: 9).
+- `rollback.sh` – reverts to the previous stable version (criticality: 9).
+
+## Deployment Strategy
+- **Blue‑green deployments:** provision the new release in an idle environment and cut traffic over only after verification.
+- **Health checks:** probe `/health` and dependent services before and after switch; failures abort promotion.
+- **Database migrations:** execute migrations against the target environment prior to traffic cutover; scripts must be idempotent.
+- **Service discovery updates:** update DNS and service registry entries once the new environment is healthy.
+- **Automatic rollback:** failed checks or alerts trigger `rollback.sh` to restore the prior environment.
+
+## Monitoring & Alerting
+- Integrate with Prometheus metrics and Alertmanager (or equivalent) to watch deployments.
+- Emit deployment events and notify the on‑call channel; watch for alerts during the post‑deploy window.
+
+## Reference
+These scripts implement the production deployment flow described in the project's schema and infrastructure documentation.

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -1,0 +1,12 @@
+# Deployment Automation
+
+This directory contains scripts that automate production deployments for the iVibe.live platform.
+
+## Scripts
+
+| File | Criticality | Purpose |
+| --- | --- | --- |
+| `deploy-prod.sh` | 9 | Perform blue‑green deployment to production, including migrations and health checks. |
+| `rollback.sh` | 9 | Restore the previous production environment if a deployment fails. |
+
+See `AGENT.md` for operational guidelines.


### PR DESCRIPTION
## Summary
- document deployment automation scripts
- describe blue-green strategy, health checks, migrations, and rollback triggers
- outline monitoring integration and alerting for production deploys

## Testing
- `npm test` *(fails: missing package.json)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689508cc8ccc832aaa633f4672436927