### PR TITLE
docs: document Android app module

### DIFF
--- a/mobile/android/app/AGENT.md
+++ b/mobile/android/app/AGENT.md
@@ -1,0 +1,11 @@
+# Android App Module Instructions
+
+- **Criticality:** 10/10
+- **Module:** Android application module for iVibe.live
+- **Language & UI:** Kotlin with Jetpack Compose for all foreground screens
+- **Background Services:** Implements the Mobile Tracking Suite schema to capture app usage, location and audio context through foreground and background services
+- **FFI:** Uses JNI bindings to Rust libraries for emotion detection and audio processing
+- **Permissions:** Handle `RECORD_AUDIO`, `CAMERA`, `ACCESS_FINE_LOCATION`, and `BLUETOOTH` with runtime checks and user prompts
+- **ProGuard/R8:** Configure rules to retain FFI bridge classes and service entry points
+- **SDK Levels:** `minSdk` 24, `targetSdk` 34
+- **Architecture Notes:** Compose UI interacts with services via `ViewModel` and `Service`/`Worker` patterns

--- a/mobile/android/app/README.md
+++ b/mobile/android/app/README.md
@@ -1,0 +1,19 @@
+# Android App Module
+
+This directory contains the Android application module for iVibe.live. It integrates with the Mobile Tracking Suite to capture on-device activity and context.
+
+## Contents
+- `build.gradle.kts` – module build script (**criticality: 10**)
+- `libs/`
+  - `.gitkeep` – placeholder to track the directory
+- `src/main/` – application sources
+  - `AndroidManifest.xml`
+  - `java/live/ivibe/`
+    - `ffi/`
+    - `services/`
+    - `ui/`
+    - `utils/`
+
+## SDK Requirements
+- **Minimum SDK:** 24
+- **Target SDK:** 34


### PR DESCRIPTION
## Summary
- document Android app module layout
- describe Kotlin, Compose, background services, Rust FFI, permissions, and ProGuard requirements

## Testing
- `gradle test --console=plain` (fails: Task 'test' not found)


------
https://chatgpt.com/codex/tasks/task_e_689508901814832a9e005eda3d05a450