### PR TITLE
docs: document Android main module

### DIFF
--- a/mobile/android/app/src/main/java/live/ivibe/AGENT.md
+++ b/mobile/android/app/src/main/java/live/ivibe/AGENT.md
@@ -1,0 +1,26 @@
+# Android Main Module Agent Instructions
+
+- **Scope:** `mobile/android/app/src/main/java/live/ivibe`
+- **Architecture:** Kotlin with Jetpack Compose and Rust FFI via JNI, minimum SDK 24, per project schema.
+- **Critical files:** `IVibeApplication.kt` (10/10), `MainActivity.kt` (10/10)
+
+## Application lifecycle
+- `IVibeApplication` boots the app, loads native libraries, and orchestrates long-running services in `onCreate`.
+- Shut down foreground services gracefully in `onTerminate` or appropriate lifecycle hooks.
+
+## Service management
+- Services live in `services/`: `TrackerService`, `LocationService`, `EmotionService`, and `VibeService`.
+- Start services from the application or activity using `startForegroundService` when background work is required.
+- Ensure permission checks for RECORD_AUDIO, CAMERA, ACCESS_FINE_LOCATION, and BLUETOOTH before launching services.
+
+## UI navigation
+- `MainActivity` hosts a Jetpack Compose `NavHost` and routes to screens under `ui/dashboard`, `ui/settings`, and `ui/vibe`.
+- Maintain navigation state in ViewModels and respect the back stack.
+
+## Native library loading
+- `ffi/NativeLib.kt` and `ffi/bindings.kt` wrap the Rust core.
+- Load `libivibe` with `System.loadLibrary` early in `IVibeApplication` and expose safe Kotlin APIs.
+- Guard against missing libraries or ABI mismatches.
+
+## Testing
+- After changes run `gradle -p mobile/android test` to verify build and unit tests.

--- a/mobile/android/app/src/main/java/live/ivibe/README.md
+++ b/mobile/android/app/src/main/java/live/ivibe/README.md
@@ -1,0 +1,23 @@
+# iVibe Android Main Module
+
+This directory holds the core Android application code for iVibe.
+
+## Contents
+- `IVibeApplication.kt` – Application entry point responsible for lifecycle and native library setup (**criticality 10**).
+- `MainActivity.kt` – Jetpack Compose activity hosting navigation among screens (**criticality 10**).
+- `ffi/`
+  - `NativeLib.kt` – loads the Rust library and exposes Kotlin wrappers.
+  - `bindings.kt` – JNI bindings to the Rust core.
+- `services/`
+  - `TrackerService.kt`
+  - `LocationService.kt`
+  - `EmotionService.kt`
+  - `VibeService.kt`
+- `ui/`
+  - `dashboard/`
+  - `settings/`
+  - `vibe/`
+- `utils/`
+  - `.gitkeep` – placeholder for future utilities.
+
+The module follows the project's Android architecture using Kotlin, Jetpack Compose, and Rust FFI.


### PR DESCRIPTION
## Summary
- add AGENT instructions for Android main module with lifecycle, services, navigation, and native lib loading
- document contents of `live/ivibe` Android package

## Testing
- `gradle -p mobile/android test` *(fails: Task 'test' not found in root project 'android')*

------
https://chatgpt.com/codex/tasks/task_e_689508a0ab10832abb659d8182af358e