### PR TITLE
docs: add manifests guidelines and overview

### DIFF
--- a/infrastructure/kubernetes/manifests/AGENT.md
+++ b/infrastructure/kubernetes/manifests/AGENT.md
@@ -1,0 +1,10 @@
+# Raw Manifest Guidelines
+
+- **Purpose**: Maintain raw Kubernetes resource files for direct application via `kubectl`.
+- **Namespace Creation**: `namespace.yaml` must define and apply the `ivibe` namespace with appropriate labels before other resources.
+- **ConfigMaps**: `configmaps.yaml` holds non‑secret configuration. Include keys such as `APP_CONFIG`, `DATABASE_URL`, and other application settings. Keep values env‑agnostic.
+- **Secrets**: Store sensitive data in `secrets.yaml` using base64‑encoded values. Encrypt secrets with tools like `kubeseal` before committing and never store plain text credentials.
+- **Deployments**: Place individual deployment YAMLs under `deployments/`. Each deployment should specify container images, ports, and health probes.
+  - Define `resources.requests` and `resources.limits` for CPU and memory.
+  - Use `securityContext` with `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, and drop unnecessary capabilities.
+- **Schema Compliance**: All manifests must conform to Kubernetes API schemas for container orchestration. Validate with `kubectl apply --dry-run=client -f <file>`.

--- a/infrastructure/kubernetes/manifests/README.md
+++ b/infrastructure/kubernetes/manifests/README.md
@@ -1,0 +1,12 @@
+# Raw Kubernetes Manifests
+
+This directory provides untemplated Kubernetes YAML files for deploying iVibe resources without Helm.
+
+## Contents
+
+- `deployments/` – container deployment specifications (.gitkeep placeholder).
+- `configmaps.yaml` – shared ConfigMap definitions (criticality: 8).
+- `namespace.yaml` – creation of the `ivibe` namespace (criticality: 9).
+- `secrets.yaml` – sensitive configuration as Kubernetes Secrets (criticality: 10).
+
+Apply manifests in the above order to ensure the namespace and configuration exist before workloads.


### PR DESCRIPTION
## Summary
- add guidelines for raw Kubernetes manifests including namespace, ConfigMap, Secret, and deployment requirements
- document manifest directory contents and file criticality levels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895088097cc832a882e482cb688832a