### PR TITLE
docs: add helm chart agent and readme

### DIFF
--- a/infrastructure/kubernetes/helm/AGENT.md
+++ b/infrastructure/kubernetes/helm/AGENT.md
@@ -1,0 +1,12 @@
+# Helm Charts
+
+- **Criticality**: 7/10
+- **Purpose**: Helm chart definitions for iVibe Kubernetes deployments
+- **Contents**:
+  - `ivibe/`
+    - `Chart.yaml`
+    - `templates/` – ConfigMaps, Secrets, Deployments, Services, Ingress rules, HorizontalPodAutoscalers, and RBAC objects
+    - `values.yaml`
+- **Namespace Isolation**: All templates scope resources to the `ivibe` namespace
+- **RBAC**: Role and RoleBinding templates enforce least-privilege access
+- **Deployment Strategy**: Follows the project's Kubernetes strategy using Helm for templated releases, enabling controlled upgrades and rollbacks

--- a/infrastructure/kubernetes/helm/README.md
+++ b/infrastructure/kubernetes/helm/README.md
@@ -1,0 +1,11 @@
+# Helm Chart Definitions
+
+This directory contains Helm chart definitions for deploying iVibe on Kubernetes.
+
+## Contents
+- `ivibe/`
+  - `Chart.yaml`
+  - `templates/`
+  - `values.yaml`
+
+The templates define ConfigMaps, Secrets, Deployments, Services, Ingress rules, HorizontalPodAutoscalers, and RBAC objects. Resources are isolated in the `ivibe` namespace. This setup follows the repository's Kubernetes deployment strategy of managing releases with Helm for repeatable upgrades and rollbacks.


### PR DESCRIPTION
## Summary
- document helm chart structure and deployment strategy
- add agent notes for helm chart templates and RBAC

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895087a854c832a9970b53d9ccc7784