### PR TITLE
docs: document terraform infrastructure directory

### DIFF
--- a/infrastructure/terraform/AGENT.md
+++ b/infrastructure/terraform/AGENT.md
@@ -1,0 +1,12 @@
+# Terraform Agent
+
+- **Criticality:** 9/10
+- **Purpose:** Provision cloud infrastructure defined by the repository schema using Terraform.
+- **Files:**
+  - `environments/` – environment-specific configs (.gitkeep)
+  - `modules/` – reusable modules (.gitkeep)
+  - `main.tf` – root configuration (criticality: 9)
+- **Resources Provisioned:** VPC networking, security groups, RDS instances, S3 buckets, IAM roles.
+- **State Management:** Use a remote backend with state locking (e.g., S3 with DynamoDB) to manage Terraform state.
+- **Schema Reference:** Align with cloud infrastructure requirements in the root `AGENTS.md` schema, ensuring secure networking, least-privilege IAM, and encrypted storage.
+- **Remote Backend:** Configure backend credentials before running `terraform init`.

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,0 +1,36 @@
+# Terraform Infrastructure
+
+This directory contains infrastructure as code for provisioning iVibe.live cloud resources using Terraform.
+
+## Contents
+
+- `environments/` – environment-specific state and variables (.gitkeep)
+- `modules/` – reusable Terraform modules (.gitkeep)
+- `main.tf` – root module entry point (criticality: 9)
+
+## Usage
+
+1. Configure the remote backend as described in `AGENT.md`.
+2. Initialize the workspace:
+
+```bash
+terraform init
+```
+3. Review infrastructure changes:
+
+```bash
+terraform plan
+```
+4. Apply changes:
+
+```bash
+terraform apply
+```
+
+## Resources
+
+Configurations provision VPC networking, security groups, RDS instances, S3 buckets, IAM roles, and other components defined in the project's cloud infrastructure schema.
+
+## State Management
+
+Terraform state is stored in a remote backend to enable collaboration and locking. Ensure backend credentials are configured before running commands.


### PR DESCRIPTION
## Summary
- add AGENT for Terraform to describe cloud resources and remote state management
- add README outlining directory structure and usage

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689508861f08832a84cc3eb2076523bc