### PR TITLE
docs: add ansible configuration overview

### DIFF
--- a/infrastructure/ansible/AGENT.md
+++ b/infrastructure/ansible/AGENT.md
@@ -1,0 +1,11 @@
+# Ansible Agent
+
+- **Criticality:** 6/10
+- **Purpose:** Configuration management for servers and services
+- **Server provisioning playbooks:** Define and provision hosts according to the deployment automation schema.
+- **Application deployment tasks:** Deploy application components consistently across environments.
+- **Configuration templating:** Use Jinja2 templates for idempotent configuration files.
+- **Secret management:** Protect credentials and variables with Ansible Vault.
+- **Idempotency:** Ensure tasks can be rerun safely and use handlers to apply changes only when needed.
+- **Role dependencies:** Declare dependencies in role `meta/main.yml` files to maintain proper execution order.
+- **Subdirectories:** `inventory/`, `playbooks/`

--- a/infrastructure/ansible/README.md
+++ b/infrastructure/ansible/README.md
@@ -1,0 +1,10 @@
+# Ansible Configuration
+
+This folder contains configuration management playbooks that support the project's deployment automation.
+
+## Structure
+
+- `inventory/` – Placeholder for host and group definitions (`.gitkeep`).
+- `playbooks/` – Placeholder for Ansible playbooks (`.gitkeep`).
+
+Add your inventories and playbooks to manage server provisioning, application deployment, and templated configuration with Ansible Vault–secured secrets.


### PR DESCRIPTION
## Summary
- document Ansible playbook directory and structure
- add agent instructions covering provisioning, deployment, templating, secrets, and idempotency

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6895088af7f0832abb7b3293e2307e65