### PR TITLE
docs: add VS Code extension metadata

### DIFF
--- a/plugins/vscode/AGENT.md
+++ b/plugins/vscode/AGENT.md
@@ -1,0 +1,19 @@
+# VS Code Extension Agent
+
+- **Criticality:** 9/10
+- **Purpose:** Capture VS Code activity for iVibe.live
+- **VS Code Extension API Usage:**
+  - Monitor workspace events (`workspace.onDidOpenTextDocument`, `onDidSaveTextDocument`, `onDidChangeWorkspaceFolders`)
+  - Track file open/save operations
+  - Detect debug sessions via `debug.onDidStartDebugSession` and `debug.onDidTerminateDebugSession`
+  - Hook into language servers and LSP diagnostics
+  - Forward events to the local iVibe gateway using HTTPS requests
+- **Activation Events:**
+  - `"*"` – activate on VS Code startup
+  - `onCommand:ivibe.start` – manual activation command
+- **Contribution Points:**
+  - `commands` for manual event dispatch and configuration
+  - `configuration` for gateway endpoint and user preferences
+  - `languages` and `debuggers` to integrate with language tools
+- **Event Schema:** Events must follow the IDE plugin specification defined in the project’s root `AGENTS.md`.
+- **Communication:** All events are batched and sent to `localhost` API endpoint for processing.

--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,1 +1,14 @@
-# VSCode Plugin
+# VS Code Extension
+
+This directory hosts the iVibe.live VS Code extension. The extension uses the VS Code Extension API to monitor workspace activity and forward events to the local iVibe gateway.
+
+## Files
+- `README.md` – overview and usage notes
+- `package.json` (criticality: 9) – extension metadata, activation events and contribution points
+- `src/extension.ts` – entry point implementing event capture
+- `tsconfig.json` – TypeScript configuration
+
+## Functionality
+- Tracks file open/save and workspace changes
+- Detects debug sessions and interacts with language servers
+- Sends captured events to `localhost` for ingestion following the IDE plugin schema


### PR DESCRIPTION
## Summary
- add AGENT.md detailing VS Code extension API usage, activation events, contribution points, and local gateway communication
- expand README with file list and functionality for the iVibe.live VS Code extension

## Testing
- `cd plugins/vscode && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689508ae6884832aa922e49fb73eb698