### PR TITLE
docs(android): document background services

### DIFF
--- a/mobile/android/app/src/main/java/live/ivibe/services/AGENTS.md
+++ b/mobile/android/app/src/main/java/live/ivibe/services/AGENTS.md
@@ -1,0 +1,14 @@
+# Android Services Instructions
+
+- **Scope:** `mobile/android/app/src/main/java/live/ivibe/services/`
+- **Purpose:** Background services powering mobile tracking features defined in the EventSchema (`location`, `vibe`, `emotion`).
+
+## Implementation Notes
+- **Foreground services:** Run each service as a `ForegroundService` with a persistent notification. Android 12+ requires an explicit notification channel and user-visible content.
+- **WorkManager scheduling:** Use `WorkManager` for deferred or periodic jobs to respect system background limits.
+- **Location updates:** Obtain updates from `FusedLocationProviderClient`, balancing accuracy and power usage.
+- **BLE scanning:** Use `BluetoothLeScanner` for Vibe discovery; handle runtime permissions and scan filters.
+- **Camera for emotion detection:** Access the camera (e.g., via `CameraX`) to capture frames for emotion analysis in `EmotionService`.
+- **Battery optimization exemptions:** Request `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` when continuous tracking is required.
+- **Notifications:** Foreground services must show ongoing notifications that satisfy Android 12+ requirements and allow users to manage settings.
+

--- a/mobile/android/app/src/main/java/live/ivibe/services/README.md
+++ b/mobile/android/app/src/main/java/live/ivibe/services/README.md
@@ -1,0 +1,14 @@
+# Android Background Services
+
+This directory contains the Android services that enable iVibe's mobile tracking features.
+
+## Files
+
+| File | Criticality | Description |
+| --- | --- | --- |
+| `EmotionService.kt` | 9 | Uses the camera to derive emotion data for upload. |
+| `LocationService.kt` | 9 | Streams GPS updates and handles geofencing. |
+| `TrackerService.kt` | 10 | Coordinates WorkManager tasks and sensor fusion. |
+| `VibeService.kt` | 10 | Scans nearby devices via Bluetooth Low Energy to detect Vibes. |
+
+All services operate as foreground services with persistent notifications on Android 12+ and request battery optimization exemptions when needed.


### PR DESCRIPTION
## Summary
- add AGENT instructions for Android background services
- document services and criticality in README

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `gradle test` *(hangs after starting Gradle Daemon; no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_689508a8b090832a8796e8de2b6041c8