### PR TITLE
docs: add seeds documentation

### DIFF
--- a/database/seeds/AGENTS.md
+++ b/database/seeds/AGENTS.md
@@ -1,0 +1,30 @@
+# Seed Data Instructions
+
+This directory contains SQL seed scripts used solely for automated tests and local development.
+
+## Demo Users
+- `demo_users.sql` inserts sample accounts across subscription tiers (Free, Basic, Pro, Team, Business).
+- Use anonymised details and fake emails; never commit real personally identifiable information.
+- Ensure tier-specific fields align with definitions in `../schemas/users.sql`.
+
+## Synthetic Events
+- `test_events.sql` generates synthetic activity events spanning typical sources.
+- Include inputs for vibe score calculations consistent with `../schemas/vibe.sql`.
+
+## Vibe Score Calculations
+- Seed data may precompute `vibe_score` or provide required inputs so database functions can derive it.
+- Verify calculations against schema tests to maintain consistency.
+
+## Cleanup Procedures
+- Test runs should remove seeded data to keep environments clean:
+  ```sql
+  TRUNCATE TABLE events, users RESTART IDENTITY CASCADE;
+  ```
+  or use transaction rollbacks in the test harness.
+
+## Data Privacy
+- Demo accounts must be clearly marked and excluded from analytics.
+- Never store or distribute real user data in this repository.
+
+## Testing Requirements
+- Before committing changes, ensure the schema compiles and run any database schema tests in `tests/` to confirm seeds remain valid.

--- a/database/seeds/README.md
+++ b/database/seeds/README.md
@@ -1,0 +1,12 @@
+# Database Seed Scripts
+
+This folder houses SQL files used to populate the database with synthetic test data. The seeds support automated tests and local development only; never run them against production systems.
+
+## Contents
+
+| File | Criticality |
+| --- | --- |
+| demo_users.sql | 6 |
+| test_events.sql | 6 |
+
+Both scripts are placeholders and should be updated as the schema evolves.


### PR DESCRIPTION
## Summary
- document database seed scripts for test data
- add guidance on demo users, synthetic events, vibe scores, cleanup, and privacy
- list seed files with criticality

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895084cb760832a93a340cd7a489112