### PR TITLE
docs: add background service worker docs

### DIFF
--- a/frontend/browser-extension/src/background/AGENTS.md
+++ b/frontend/browser-extension/src/background/AGENTS.md
@@ -1,0 +1,17 @@
+# Background Service Worker Guidelines
+
+This directory contains the background service worker for the browser extension and follows the `aw-watcher-browser` specification described in the project schema.
+
+## Responsibilities
+- Track tab focus and monitor URL changes through Chrome Extension APIs.
+- Detect AI platforms such as ChatGPT, Claude, and Gemini.
+- Estimate token usage for detected AI conversations.
+- Batch captured events before transmission.
+- Stream event batches via WebSocket to `ws://localhost:8081`.
+- Store pending events in IndexedDB as a fallback when offline.
+- Communicate with content scripts and other extension parts using Chrome's runtime messaging.
+
+## File Overview
+- **index.ts** (criticality 10) – service worker entry and orchestration.
+- **ai-detector.ts** (criticality 9) – identifies AI platforms and estimates token usage.
+- **tracker.ts** (criticality 9) – handles tab focus, URL tracking, batching, WebSocket, and storage.

--- a/frontend/browser-extension/src/background/README.md
+++ b/frontend/browser-extension/src/background/README.md
@@ -1,0 +1,8 @@
+# Background Service Worker
+
+This folder implements the browser extension's background service worker. It tracks tab focus, monitors URL changes, detects AI platforms (ChatGPT, Claude, Gemini), estimates token usage, batches events, and streams them to `ws://localhost:8081`. Pending events are stored in IndexedDB until a connection is available. The worker communicates with other extension components via Chrome Extension APIs and adheres to the project's browser watcher schema.
+
+## Files
+- **index.ts** – service worker entry point. _Criticality: 10_
+- **ai-detector.ts** – AI platform detection and token usage estimation. _Criticality: 9_
+- **tracker.ts** – focus and URL tracker with event batching, WebSocket handling, and storage. _Criticality: 9_


### PR DESCRIPTION
## Summary
- document browser extension background service worker
- outline responsibilities like tab tracking, AI detection, and WebSocket streaming

## Testing
- `pnpm test` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689507ecba78832a8f90721911941435