### PR TITLE
docs: add services documentation

### DIFF
--- a/frontend/web/src/services/AGENTS.md
+++ b/frontend/web/src/services/AGENTS.md
@@ -1,0 +1,26 @@
+# Services Layer Guidelines
+
+This folder implements the frontend service layer responsible for all API communication.
+
+## Files
+- `api.ts` – base Axios HTTP client and interceptors *(criticality: 10)*
+- `auth.ts` – JWT token utilities and refresh logic *(criticality: 10)*
+- `websocket.ts` – WebSocket manager for real‑time events *(criticality: 9)*
+
+## HTTP Client
+- Use **Axios** for all HTTP requests.
+- Configure interceptors to attach JWT access tokens from `localStorage`.
+- Interceptors must detect `401` responses and trigger automatic token refresh.
+- Implement robust error handling with retry strategies for transient failures.
+
+## Authentication
+- Manage JWT tokens in `localStorage`.
+- Provide helpers for refreshing tokens and updating stored credentials.
+
+## WebSocket
+- Connect to `ws://localhost:8081` for realtime features.
+- Expose an event subscription pattern for consumers.
+- Implement exponential backoff when reconnecting after disconnections.
+- Include error handling and retry logic for dropped connections.
+
+These conventions align with the project's schema for the **frontend service layer**.

--- a/frontend/web/src/services/README.md
+++ b/frontend/web/src/services/README.md
@@ -1,0 +1,10 @@
+# Services
+
+This directory holds API communication services for the web frontend.
+
+## Files
+- `api.ts` – Configured Axios instance with interceptors.
+- `auth.ts` – Handles JWT storage, access and refresh tokens.
+- `websocket.ts` – Manages WebSocket connection to `ws://localhost:8081` with automatic reconnection.
+
+These modules form the frontend service layer as described in the project schema, enabling secure HTTP requests and realtime updates.


### PR DESCRIPTION
## Summary
- document API service layer expectations for web frontend
- add README describing available service modules

## Testing
- `npm test --prefix frontend/web` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689507dd2a30832a8a9da65f8b8e9342