### PR TITLE
docs: add shared models folder guide

### DIFF
--- a/backend/shared/models/src/AGENT.md
+++ b/backend/shared/models/src/AGENT.md
@@ -1,0 +1,25 @@
+# Shared Data Models Guide
+
+This directory hosts data models shared across backend services.
+
+## Event
+- Defined in `event.rs`, mapping to the `events` table (`database/schemas/events.sql`).
+- Struct should include `event_id: Uuid`, `user_id: Uuid`, and `timestamp: DateTime<Utc>`.
+- Implements `Serialize`, `Deserialize`, and `FromRow` for database and API serialization.
+- Apply validation to ensure UUID formats and required fields.
+
+## User
+- Defined in `user.rs`, mirroring the `users` table (`database/schemas/users.sql`).
+- Includes tier and `subscription_id` fields to support billing.
+- Derive `Serialize`, `Deserialize`, `FromRow`; validate tier enums and subscription presence.
+
+## Vibe
+- `vibe.rs` contains models for vibe scoring stored in `vibe` table (`database/schemas/vibe.sql`).
+- Models capture metrics contributing to vibe scores.
+- Derive `Serialize`, `Deserialize`, `FromRow` and enforce score bounds through validation.
+
+## Common
+All models must:
+- Stay aligned with schema specifications in `/database/schemas`.
+- Expose API contract definitions matching these structs.
+- Use validation implementations to guard business rules.

--- a/backend/shared/models/src/README.md
+++ b/backend/shared/models/src/README.md
@@ -1,0 +1,11 @@
+# Shared Models
+
+This folder contains data models shared across backend components.
+
+## Files
+- `event.rs` — core event record model *(criticality: 9)*
+- `user.rs` — user account model with tier and subscription fields *(criticality: 9)*
+- `vibe.rs` — vibe scoring models *(criticality: 9)*
+- `lib.rs` — module exports *(criticality: 8)*
+
+Refer to the schema definitions under `database/schemas` for authoritative data model specifications.


### PR DESCRIPTION
## Summary
- document shared backend models with guidance on events, users and vibe scoring
- add README listing models and criticality

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689507c48c3c832aab8f6d67e94b2af0