### PR TITLE
docs(cli): add command module docs

### DIFF
--- a/backend/cli/src/commands/AGENT.md
+++ b/backend/cli/src/commands/AGENT.md
@@ -1,0 +1,13 @@
+# Agent Instructions
+
+- **Criticality**: 9/10
+- **Purpose**: Implement `ivb` CLI commands
+- **Commands**:
+  - `ivb capture`: manual event submission
+  - `ivb export`: data retrieval
+  - `ivb account`: subscription management
+  - `ivb config`: settings and configuration
+- **API Authentication**: attach bearer tokens as specified in the project schema's CLI tool specification
+- **Output Formatting**: support JSON and CSV responses
+- **Error Handling**: validate API responses and return clear exit codes
+- **Reference**: follow the schema's CLI tool specifications for command syntax

--- a/backend/cli/src/commands/README.md
+++ b/backend/cli/src/commands/README.md
@@ -1,0 +1,13 @@
+# CLI Command Implementations
+
+This folder contains the implementation of individual commands for the `ivb` CLI. These modules follow the project's CLI tool specification for authentication and output formatting.
+
+## Files
+
+- `capture.rs` (criticality: 9) – submit manual events to the API.
+- `export.rs` (criticality: 8) – retrieve stored data as JSON or CSV.
+- `account.rs` (criticality: 8) – manage login and subscription state.
+- `config.rs` (criticality: 8) – read and update local settings.
+- `mod.rs` (criticality: 8) – wire commands into the CLI dispatcher.
+
+All commands require API authentication and provide robust error handling.


### PR DESCRIPTION
## Summary
- document CLI command modules for ivb
- add agent instructions covering auth, output formats, and error handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689507b832d0832a8e989e590de4623d