### PR TITLE
docs: add route handler guidance

### DIFF
--- a/backend/api/rest-api/src/routes/AGENT.md
+++ b/backend/api/rest-api/src/routes/AGENT.md
@@ -1,0 +1,13 @@
+# Routes Agent Instructions
+
+This directory houses REST API route handlers. Follow these guidelines when modifying or adding endpoints.
+
+## Endpoints
+
+- **POST `/events`** – Accept batched event submissions. Validate the caller's tier and enforce rate limiting according to the API endpoint matrix.
+- **GET `/dashboard`** – Return dashboard metrics. Responses must be cached for 60 seconds. Apply tier checks and rate limits.
+- **GET `/export`** – Generate data exports in CSV, JSON, or PDF. Perform tier validation and rate limit export frequency. Reference the schema's API endpoint matrix for supported formats.
+- **GET `/vibe/nearby`** – Provide real-time proximity data. Ensure tier validation and rate limiting.
+- **Integration management** – Endpoints for listing, adding, and removing integrations must always enforce tier validation and rate limiting.
+
+Consult the schema's API endpoint matrix for field definitions, tier rules, and overall route consistency.

--- a/backend/api/rest-api/src/routes/README.md
+++ b/backend/api/rest-api/src/routes/README.md
@@ -1,0 +1,12 @@
+# Routes
+
+This folder contains REST API route handlers.
+
+## Files
+
+- `dashboard.rs` – Dashboard metrics handler (criticality: 8)
+- `events.rs` – Event ingestion handler (criticality: 9)
+- `export.rs` – Data export handler (criticality: 8)
+- `integrations.rs` – Integration management endpoints (criticality: 8)
+- `mod.rs` – Module declaration and route registration (criticality: 8)
+- `vibe.rs` – Nearby vibe discovery endpoints (criticality: 9)


### PR DESCRIPTION
## Summary
- add AGENT instructions for route handlers including tier validation and rate limiting
- document routes directory with file criticality levels

## Testing
- `cargo audit` *(failed: no such command and install error: CONNECT tunnel failed, response 403)*
- `cargo deny check` *(failed: no such command and install error: CONNECT tunnel failed, response 403)*
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_e_689507a693cc832a8ee1cd9ea8620904