### PR TITLE
docs: add REST API source guidance

### DIFF
--- a/backend/api/rest-api/src/AGENT.md
+++ b/backend/api/rest-api/src/AGENT.md
@@ -1,0 +1,11 @@
+# REST API Source Instructions
+
+- **Server:** Actix Web running on port 8080.
+- **Authentication:** JWT middleware enforces identity checks in `middleware/auth.rs`.
+- **Access Control:** `middleware/tier.rs` applies tier-based permissions for each request.
+- **Routes:** Handlers in `routes/` manage dashboard, events, export, integrations and vibe endpoints.
+- **Validation:** Each handler validates incoming parameters and body content against the REST API schema.
+- **Responses:** Serialize responses to JSON with consistent error formatting.
+- **Persistence:** Query PostgreSQL for all data operations.
+- **Caching:** Use Redis to cache frequently accessed resources such as dashboard metrics.
+- **Specification:** Refer to the REST API schema in `../README.md` for endpoint definitions and expected models.

--- a/backend/api/rest-api/src/README.md
+++ b/backend/api/rest-api/src/README.md
@@ -1,0 +1,22 @@
+# REST API Source
+
+Rust source code for the Actix Web REST API server.
+
+## Structure
+
+- `main.rs` – entry point (**criticality: 10**)
+- `middleware/`
+  - `auth.rs`
+  - `mod.rs`
+  - `tier.rs`
+- `models/`
+  - `mod.rs`
+- `routes/`
+  - `dashboard.rs`
+  - `events.rs`
+  - `export.rs`
+  - `integrations.rs`
+  - `mod.rs`
+  - `vibe.rs`
+
+The server listens on port 8080 and relies on JWT authentication, tier-based access control, PostgreSQL, and Redis caching. See `../README.md` for the full REST API specification.


### PR DESCRIPTION
## Summary
- document REST API source layout and responsibilities
- note Actix Web server, JWT auth, tier control, PostgreSQL and Redis caching

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689507a056e0832a865a61b04cd446e8