### PR TITLE
docs: add emotion detection source guidance

### DIFF
--- a/backend/intelligence/emotion-detection/src/AGENT.md
+++ b/backend/intelligence/emotion-detection/src/AGENT.md
@@ -1,0 +1,15 @@
+# Agent Instructions
+
+- **Scope**: `backend/intelligence/emotion-detection/src`
+- **Purpose**: On-device emotion analysis implementation.
+- **Files**:
+  - `camera/` (`capture.rs`, `mod.rs`, `platform.rs`)
+  - `wasm/` (`mod.rs`, `model.rs`)
+  - `classifier.rs` – criticality: 9
+  - `context.rs` – criticality: 9
+  - `main.rs` – criticality: 10
+- **Camera frame capture**: `camera::capture` streams frames via Video4Linux2 (Linux), AVFoundation (macOS) or Media Foundation (Windows).
+- **Facial detection & classification**: detect faces then label smile, laugh, cry, fear and anger.
+- **Context screenshot capture**: `context` records active window imagery for trigger context.
+- **Trigger association**: pair emotion events with app, URL and location following the emotion analytics schema (`emotion_events`, `mv_emotions`).
+- **WASM model inference**: `wasm::model` runs WebAssembly inference for cross-platform consistency.

--- a/backend/intelligence/emotion-detection/src/README.md
+++ b/backend/intelligence/emotion-detection/src/README.md
@@ -1,0 +1,18 @@
+# Emotion Detection Source
+
+Rust implementation for capturing camera frames, detecting faces, classifying emotions and recording context for analytics.
+
+## Structure
+
+- `camera/`
+  - `capture.rs`
+  - `mod.rs`
+  - `platform.rs`
+- `wasm/`
+  - `mod.rs`
+  - `model.rs`
+- `classifier.rs` – criticality: 9
+- `context.rs` – criticality: 9
+- `main.rs` – criticality: 10
+
+Events emitted from this module feed the platform's emotion analytics features such as the `emotion_events` table and `mv_emotions` view.


### PR DESCRIPTION
## Summary
- document emotion-detection src layout and criticality
- add agent instructions covering capture, classification, and WASM inference

## Testing
- `cargo test`
- `cargo audit` *(fails: no such command)*
- `cargo install cargo-audit` *(fails: failed to download from crates.io)*
- `cargo deny check` *(fails: no such command)*
- `cargo install cargo-deny` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_689507939844832aad0c8bf6aedf2ebc