### PR TITLE
docs: document vectorizer service source

### DIFF
--- a/backend/services/vectorizer-service/src/AGENT.md
+++ b/backend/services/vectorizer-service/src/AGENT.md
@@ -1,0 +1,10 @@
+# Vectorizer Service Source Agent
+
+- **Purpose:** Implement the vectorization stage of the schema's pipeline by turning incoming text into embeddings.
+- **Kafka:** Consume the `events_raw` topic and extract textual payload fields.
+- **OpenAI:** Call `text-embedding-3-small` via the Helicone proxy for remote embedding generation.
+- **Fallback:** When remote calls fail, defer to local models under `local_models/`.
+- **Storage:** Persist resulting vectors in PostgreSQL using the `pgvector` extension.
+- **Cache:** Store embeddings in Redis with a TTL of `86400s` to avoid recalculation.
+
+This source tree powers the embedding generation service used across the platform.

--- a/backend/services/vectorizer-service/src/README.md
+++ b/backend/services/vectorizer-service/src/README.md
@@ -1,0 +1,15 @@
+# Vectorizer Service Source
+
+This directory contains the embedding generation service.
+
+## Layout
+- `local_models/`
+  - `fallback.rs`
+  - `mod.rs`
+- `openai/`
+  - `client.rs`
+  - `embeddings.rs`
+  - `mod.rs`
+- `kafka_consumer.rs` *(criticality: 10)*
+- `main.rs` *(criticality: 10)*
+- `storage.rs` *(criticality: 9)*


### PR DESCRIPTION
## Summary
- add AGENT.md detailing Kafka to pgvector pipeline with OpenAI and Redis caching
- document src layout and critical files in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895076f020c832aaf4c034a415d31bc