### PR TITLE
docs: document aw-server-rust ingestion service

### DIFF
--- a/backend/services/aw-server-rust/src/AGENTS.md
+++ b/backend/services/aw-server-rust/src/AGENTS.md
@@ -1,0 +1,19 @@
+# aw-server-rust/src Agent Instructions
+
+This directory hosts the Rust event ingestion service that powers the platform's processing plane ingestion.
+
+## Responsibilities
+- **Batch event processing:** `ingestion/batch.rs` coordinates gRPC `EventBatch` messages and splits them into individual events.
+- **Schema validation:** `ingestion/validator.rs` enforces the event schema before any storage operations.
+- **TimescaleDB hypertable insertion:** `storage/postgres.rs` writes validated JSON events into hypertables for efficient time-series queries.
+- **Kafka publishing:** `storage/kafka.rs` publishes each event to the `events_raw` topic for downstream consumers.
+- **MinIO object storage:** `storage/minio.rs` stores binary payloads (such as audio) in object storage while keeping hashes and metadata in Postgres.
+- **Debezium CDC setup:** database changes are captured and streamed to Kafka to keep processing pipelines in sync.
+
+## Directory Layout
+- `ingestion/`
+- `models/`
+- `storage/`
+- `main.rs`
+
+These components implement the event ingestion path defined in the schema's processing plane.

--- a/backend/services/aw-server-rust/src/README.md
+++ b/backend/services/aw-server-rust/src/README.md
@@ -1,0 +1,20 @@
+# aw-server-rust Event Ingestion
+
+This `src` directory contains the event ingestion service for `aw-server-rust`.
+
+## Structure
+- `ingestion/`
+  - `batch.rs`
+  - `mod.rs`
+  - `validator.rs`
+- `models/`
+  - `event.rs`
+  - `mod.rs`
+- `storage/`
+  - `kafka.rs`
+  - `minio.rs`
+  - `mod.rs`
+  - `postgres.rs`
+- `main.rs` *(criticality: 10)*
+
+The service validates event batches, inserts data into TimescaleDB, publishes to the `events_raw` Kafka topic, and persists binary objects in MinIO.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for aw-server-rust event ingestion
- document directory layout for aw-server-rust/src

## Testing
- `cd backend/services/aw-server-rust && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689507491ee4832a97ed6b424b3aa014