### PR TITLE
docs: add auth module guidance

### DIFF
--- a/backend/services/event-gateway/src/auth/AGENT.md
+++ b/backend/services/event-gateway/src/auth/AGENT.md
@@ -1,0 +1,15 @@
+# Auth Module
+
+- **Criticality**: 10/10
+- **Purpose**: Authentication and authorization for the event gateway
+- **Owned Files**:
+  - `jwt.rs` – criticality 10/10
+  - `keycloak.rs` – criticality 10/10
+  - `mod.rs` – criticality 8/10
+- **Key Responsibilities**:
+  - Validate JWT tokens issued by Keycloak
+  - Communicate with Keycloak OIDC endpoints at `/auth/realms/ivibe`
+  - Extract `tenant_id` from token claims for downstream services
+  - Refresh JWKS certificates to handle Keycloak key rotation
+  - Cache session data in Redis with a 3600s TTL to reduce Keycloak load
+- **Reference**: See project schema for identity provider integration details

--- a/backend/services/event-gateway/src/auth/README.md
+++ b/backend/services/event-gateway/src/auth/README.md
@@ -1,0 +1,18 @@
+# Auth Module
+
+This directory implements authentication and authorization for the event gateway, integrating with Keycloak as the identity provider.
+
+## Files
+
+| File | Criticality |
+| --- | --- |
+| `jwt.rs` | 10 |
+| `keycloak.rs` | 10 |
+| `mod.rs` | 8 |
+
+## Overview
+
+- Validates JWT tokens and extracts `tenant_id` claims.
+- Communicates with Keycloak at `/auth/realms/ivibe` for OIDC operations.
+- Handles certificate rotation and caches sessions in Redis with a 3600 s TTL.
+- Supports the identity provider integration defined in the project schema.


### PR DESCRIPTION
## Summary
- document auth module responsibilities and keycloak integration

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68950730aed0832aa060194213f29b60