### PR TITLE
docs: add audio watcher agent and readme

### DIFF
--- a/backend/watchers/aw-watcher-audio/src/AGENTS.md
+++ b/backend/watchers/aw-watcher-audio/src/AGENTS.md
@@ -1,0 +1,24 @@
+# Audio Watcher Agent Instructions
+
+This directory implements privacy-preserving audio capture and vectorization for iVibe.
+
+- Capture microphone audio at **16 kHz mono** using platform audio APIs:
+  - PulseAudio on Linux
+  - WASAPI on Windows
+  - CoreAudio on macOS
+- Apply **WebRTC Voice Activity Detection (VAD)** to gate processing and limit work to speech segments.
+- Support **hot-word triggering**; only when the hot word fires should the subsequent audio be embedded.
+- Generate audio embeddings **on-device** via `vectorizer.rs` and **discard raw audio** immediately.
+- Attach relevant metadata (timestamp, device, hot-word tag) to each embedding event.
+- Emit events that conform to the project's schema for **privacy-preserving audio vectorization**; no raw audio leaves the machine.
+
+## Files and Criticality
+
+| File | Criticality |
+| --- | --- |
+| `capture.rs` | 9 |
+| `hotword.rs` | 8 |
+| `main.rs` | 10 |
+| `privacy.rs` | 10 |
+| `vectorizer.rs` | 10 |
+

--- a/backend/watchers/aw-watcher-audio/src/README.md
+++ b/backend/watchers/aw-watcher-audio/src/README.md
@@ -1,0 +1,14 @@
+# aw-watcher-audio `src`
+
+Source files for the audio watcher that captures microphone input, detects hot words, generates on-device embeddings and discards raw audio. It interfaces with PulseAudio, WASAPI, or CoreAudio and operates at 16 kHz mono with WebRTC VAD for speech gating.
+
+## Files
+
+| File | Criticality | Description |
+| --- | --- | --- |
+| `capture.rs` | 9 | Audio device interface and buffering |
+| `hotword.rs` | 8 | Hot-word detection and triggering |
+| `main.rs` | 10 | Entrypoint orchestrating capture, VAD and embedding |
+| `privacy.rs` | 10 | Ensures raw audio is discarded and metadata attached |
+| `vectorizer.rs` | 10 | On-device audio embedding generation |
+


### PR DESCRIPTION
## Summary
- document audio watcher responsibilities in new AGENT.md
- describe source layout and critical files in README.md

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895071c644c832a9531cdcf81545df4