### PR TITLE
docs: document terminal watcher source

### DIFF
--- a/backend/watchers/aw-watcher-terminal/src/AGENT.md
+++ b/backend/watchers/aw-watcher-terminal/src/AGENT.md
@@ -1,0 +1,7 @@
+- Criticality: 10/10
+- Purpose: Capture terminal commands and error intelligence for ActivityWatch
+- Shell hook installation: `shell/*.rs` inject hooks into Bash, Zsh, Fish, and PowerShell profiles
+- Command interception: DEBUG/ERR traps record each command, working directory, and exit status before execution
+- Stderr capture & classification: watcher streams stderr, tagging output as error, warning, or info
+- Error fix detection: pattern matching spots reruns that resolve previous failures
+- Event transmission: structured events (`source: terminal`, command, stderr, classification, fix_detected) sent to the Event Gateway

--- a/backend/watchers/aw-watcher-terminal/src/README.md
+++ b/backend/watchers/aw-watcher-terminal/src/README.md
@@ -1,0 +1,21 @@
+# aw-watcher-terminal: source
+
+This folder contains the terminal command tracking logic for ActivityWatch.
+It installs shell hooks, intercepts commands with DEBUG traps, captures stderr,
+classifies errors, detects fixes, and forwards events using the terminal
+intelligence schema.
+
+## Layout
+
+- shell/
+  - bash.rs
+  - fish.rs
+  - zsh.rs
+  - powershell.rs
+  - mod.rs
+- command_parser.rs – criticality: 9
+- error_detection.rs – criticality: 9
+- main.rs – criticality: 10
+
+These components work together to observe user commands and transmit structured
+events for downstream analysis.


### PR DESCRIPTION
## Summary
- add AGENT instructions covering shell hooks, DEBUG traps, stderr capture, fix detection, and event transmission
- document terminal watcher source layout and critical modules

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895070a6768832aa12c029b14d2f509