### PR TITLE
docs: document gRPC client module for aw-watcher-window

### DIFF
--- a/backend/watchers/aw-watcher-window/src/grpc/AGENT.md
+++ b/backend/watchers/aw-watcher-window/src/grpc/AGENT.md
@@ -1,0 +1,17 @@
+# gRPC Transport Agent Instructions
+
+This directory implements the gRPC transport layer used by `aw-watcher-window` to send events to the central event gateway.
+
+## File Criticality
+- `client.rs` – **10** – connection handling, streaming logic, retries.
+- `mod.rs` – **8** – module exports and shared utilities.
+
+## Implementation Notes
+- **Transport**: Follow the event schema's transport plane protocols using gRPC over HTTP/2 on port `50051`.
+- **TLS**: Validate server certificates and optionally present a client certificate. Use the system trust store or a bundled CA file.
+- **Authentication**: Obtain JWTs from Keycloak via OAuth2 client credentials. Attach the token as `authorization: Bearer <token>` metadata on every call and refresh before expiration.
+- **Streaming**: Stream `EventBatch` messages with back-pressure and request size checks defined by the schema.
+- **Reconnection**: When the gateway connection drops, retry with exponential backoff (e.g., 1s, 2s, 4s…) up to a sane limit.
+- **Local Queueing**: If the gateway remains unavailable, queue events locally and flush once a connection is re-established.
+
+These instructions guide future development of the transport layer while keeping authentication and reliability aligned with the overall system design.

--- a/backend/watchers/aw-watcher-window/src/grpc/README.md
+++ b/backend/watchers/aw-watcher-window/src/grpc/README.md
@@ -1,0 +1,15 @@
+# gRPC Client for Event Gateway
+
+This module handles all gRPC communication between `aw-watcher-window` and the event gateway.
+
+## Features
+- Streams `EventBatch` messages over port `50051` using gRPC as defined by the event schema's transport plane protocols.
+- Secures traffic with TLS, validating gateway certificates and supporting client-side certificates.
+- Authenticates requests by obtaining JWTs from Keycloak and attaching them as bearer tokens.
+- Implements reconnection with exponential backoff and queues events locally when the gateway is unreachable.
+
+## Files
+- `client.rs` – gRPC client implementation and reconnection logic.
+- `mod.rs` – Module declaration and shared exports.
+
+See `AGENT.md` for implementation guidance and operational expectations.


### PR DESCRIPTION
## Summary
- add AGENT instructions for gRPC client detailing TLS, JWT authentication, and reconnection strategy
- document gRPC module responsibilities and file roles

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689506f28030832ab0f296518e469060