### PR TITLE
docs: add platform capture module docs

### DIFF
--- a/backend/watchers/aw-watcher-window/src/capture/AGENT.md
+++ b/backend/watchers/aw-watcher-window/src/capture/AGENT.md
@@ -1,0 +1,28 @@
+# Platform Capture Guidelines
+
+This directory hosts per-platform modules that feed window activity into iVibe's event pipeline. Each implementation listens for native window focus changes, extracts metadata, and forwards structured events to `aw-server-rust` via gRPC `EventBatch` messages.
+
+## linux.rs (criticality: 10)
+- **Hooks**: Listens to focus events from X11 or Wayland compositors; queries DBus when session managers expose additional hints.
+- **Extraction**: Reads window titles, application names, and file paths via `_NET_WM_NAME` or DBus properties.
+- **Fallbacks**: Polls the root window and DBus when event streams fail.
+- **Compatibility**: Normalises output into the shared `WindowEvent` schema before batching.
+
+## macos.rs (criticality: 10)
+- **Hooks**: Subscribes to Accessibility API callbacks and `NSWorkspace` notifications for the frontmost application.
+- **Extraction**: Retrieves window title, bundle identifier, and document URL through `AXTitle` and `AXDocument` attributes.
+- **Fallbacks**: Falls back to periodic polling when Accessibility notifications are denied.
+- **Compatibility**: Maps data into the cross-platform schema and streams via gRPC.
+
+## windows.rs (criticality: 10)
+- **Hooks**: Uses `SetWinEventHook` and UIAutomation to detect foreground window changes.
+- **Extraction**: Captures window text (`GetWindowTextW`), process names, and document paths via Automation patterns.
+- **Fallbacks**: Polls `GetForegroundWindow` when hooks are unavailable.
+- **Compatibility**: Ensures UTF-8 normalization and emits schema-compliant events.
+
+## mod.rs (criticality: 9)
+- Selects the appropriate platform implementation using `cfg` attributes.
+- Exposes a common trait to start/stop capture and emit `WindowEvent` instances.
+- Maintains uniform communication patterns across platforms.
+
+All modules must conform to the global `EventSchema` (`event_id`, `user_id`, `timestamp`, `source`, `payload`), ensuring consistent cross-platform behaviour.

--- a/backend/watchers/aw-watcher-window/src/capture/README.md
+++ b/backend/watchers/aw-watcher-window/src/capture/README.md
@@ -1,0 +1,12 @@
+# Window Capture Modules
+
+This directory contains platform-specific implementations for capturing active window information in `aw-watcher-window`.
+
+| File | Criticality | Purpose |
+| --- | --- | --- |
+| `linux.rs` | 10 | Captures window events on Linux using X11/Wayland and DBus. |
+| `macos.rs` | 10 | Uses the macOS Accessibility API and `NSWorkspace` notifications. |
+| `windows.rs` | 10 | Hooks into Win32 events and UIAutomation on Windows. |
+| `mod.rs` | 9 | Selects the correct platform module and exposes a common interface. |
+
+Each module reports window titles, application names, and file paths to the shared `aw-server-rust` backend.


### PR DESCRIPTION
## Summary
- document platform-specific window capture implementations
- explain how each OS module hooks into native events and sends schema-compliant data

## Testing
- `cargo test -p aw-watcher-window`


------
https://chatgpt.com/codex/tasks/task_e_689506df62fc832a8c35c5d1ebef3d4a