### PR TITLE
docs: document GitLab CI audit scripts

### DIFF
--- a/.gitlab/ci/scripts/AGENT.md
+++ b/.gitlab/ci/scripts/AGENT.md
@@ -1,0 +1,14 @@
+# GitLab CI Scripts Agent
+
+- **Criticality:** 9/10
+- **Purpose:** Shell utilities that enforce supply chain security in GitLab CI jobs.
+- **Files:**
+  - `cargo-audit.sh` – criticality: 9
+  - `npm-audit.sh` – criticality: 9
+- **Communication:**
+  - `cargo-audit.sh` reaches the crates.io index and RustSec advisory database.
+  - `npm-audit.sh` queries the npm registry and audit database.
+- **Behaviour:**
+  - Emit audit reports to job logs and attach them as CI artifacts.
+  - Exit with a non-zero status to fail pipelines when vulnerabilities are found.
+- **SupplyChainRiskMitigation:** Implements schema requirements such as `UseCargoAudit`, `AuditInCI`, `CommitLockfile`, and `UseVersionResolutions` to detect dependency risks early.

--- a/.gitlab/ci/scripts/README.md
+++ b/.gitlab/ci/scripts/README.md
@@ -1,0 +1,12 @@
+# GitLab CI Scripts
+
+This directory contains shell scripts executed by GitLab CI jobs to audit dependencies and enforce the project's supply chain risk mitigation policy. Each script talks to external registries and vulnerability databases, reports findings back to the pipeline, and halts the build if issues are detected. Audit logs are preserved as CI artifacts for traceability.
+
+## Files
+
+| File | Criticality | Description |
+| --- | --- | --- |
+| `cargo-audit.sh` | 9 | Runs `cargo audit` against crates.io and the RustSec advisory database. |
+| `npm-audit.sh` | 9 | Runs `npm audit --production` against the npm registry and its vulnerability database. |
+
+These checks implement the **SupplyChainRiskMitigation** schema by verifying Rust and TypeScript dependencies during continuous integration.


### PR DESCRIPTION
## Summary
- add AGENT.md for GitLab CI security scripts
- add README.md describing CI audit scripts and criticality

## Testing
- `.gitlab/ci/scripts/cargo-audit.sh` *(fails: no such command `audit`)*
- `.gitlab/ci/scripts/npm-audit.sh` *(fails: missing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689506c77484832ab1650b6f981752db