### PR TITLE
docs(ci): document GitLab CI job templates

### DIFF
--- a/.gitlab/ci/jobs/AGENT.md
+++ b/.gitlab/ci/jobs/AGENT.md
@@ -1,0 +1,20 @@
+# GitLab CI Jobs Agent
+
+- **Criticality:** 8/10
+- **Purpose:** Defines job templates for the GitLab CI/CD pipeline (Build → Test → Security → Deploy) described in the project's schema.
+- **Files:**
+  - `build.yml` – criticality: 8
+  - `test.yml` – criticality: 8
+  - `deploy.yml` – criticality: 9
+  - `security.yml` – criticality: 9
+- **Communication with Runners:** Jobs run on GitLab runners (Arch Linux) using Docker executors. Each job spins up a container, executes cargo/npm commands, and streams logs and status back to the pipeline so merge requests reflect success or failure.
+- **Docker Builds:** The build job triggers Docker builds and pushes resulting images to the project registry.
+- **Commands:**
+  - `build.yml` compiles code and packages images.
+  - `test.yml` runs `cargo test` and `npm test`.
+  - `security.yml` calls `cargo audit` and `npm audit` via scripts in `../scripts`.
+  - `deploy.yml` uses built artifacts or images to update deployment targets.
+- **Artifacts & Cache:** Jobs upload binaries, reports, and container images to GitLab's artifact storage. Shared caches preserve Cargo and npm dependencies between stages, reducing pipeline time.
+- **Status Reporting:** Pipeline results are posted back to merge requests through GitLab's CI status API.
+- **Deployment Targets:** Deployments interact with environments such as Kubernetes clusters or Docker hosts defined by the infrastructure manifests.
+

--- a/.gitlab/ci/jobs/README.md
+++ b/.gitlab/ci/jobs/README.md
@@ -1,0 +1,15 @@
+# GitLab CI Jobs
+
+This directory contains GitLab CI job definitions referenced by the root `.gitlab-ci.yml`. The jobs mirror the pipeline architecture described in the project schema: **Build → Test → Security → Deploy**.
+
+## Job Files
+
+| File | Criticality | Description |
+| --- | --- | --- |
+| `build.yml` | 8 | Compile sources and build Docker images |
+| `test.yml` | 8 | Execute `cargo test` and `npm test` |
+| `security.yml` | 9 | Run dependency and container security checks |
+| `deploy.yml` | 9 | Publish artifacts or images to deployment targets |
+
+Jobs run on GitLab runners using Docker. They leverage caches to reuse Cargo and npm dependencies and upload artifacts (binaries, reports, images) for later stages. Status for each job is reported back to merge requests so reviewers can track pipeline results.
+


### PR DESCRIPTION
## Summary
- add AGENT.md describing GitLab job communication patterns, cache use, and deployment targets
- document build, test, security, and deploy jobs in README.md

## Testing
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689506b4f94c832a9437bca4d68339ff