### PR TITLE
docs: add window watcher agent and readme

### DIFF
--- a/backend/watchers/aw-watcher-window/src/AGENT.md
+++ b/backend/watchers/aw-watcher-window/src/AGENT.md
@@ -1,0 +1,18 @@
+# AGENT Instructions
+
+This directory contains the cross-platform window watcher for the capture plane.
+
+## Platform Communication
+- **Linux:** capture active window events via DBus.
+- **Windows:** use Win32 APIs to monitor foreground window changes.
+- **macOS:** rely on the Accessibility API for window focus notifications.
+
+Keep platform-specific logic isolated within the `capture/` module.
+
+## Event Flow
+- Batch window events every 1–5 seconds to minimise overhead.
+- Stream batches through the gRPC client to the event gateway.
+- Ensure emitted events follow the capture plane schema (event_id, user_id, timestamp, source, project, language, payload).
+
+## Architecture Notes
+This watcher operates in the capture plane and should only handle collection and forwarding of window events. Processing or storage belongs elsewhere in the pipeline.

--- a/backend/watchers/aw-watcher-window/src/README.md
+++ b/backend/watchers/aw-watcher-window/src/README.md
@@ -1,0 +1,20 @@
+# aw-watcher-window Source
+
+This folder contains the core window tracking implementation for the ActivityWatch window watcher.
+
+## Structure
+- `capture/`
+  - `linux.rs`
+  - `macos.rs`
+  - `windows.rs`
+  - `mod.rs`
+- `events/`
+  - `mod.rs`
+  - `window_event.rs`
+- `grpc/`
+  - `client.rs`
+  - `mod.rs`
+- `lib.rs` – library entry point *(criticality: 9)*
+- `main.rs` – binary entry point *(criticality: 10)*
+
+The `capture` module provides platform-specific window polling, `events` defines event types, and `grpc` streams batched events to the event gateway.


### PR DESCRIPTION
## Summary
- document platform capture and streaming details for window watcher
- add README describing module layout and file criticality

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689506d52018832a8799ce2cb50965be