### PR TITLE
docs: add event gateway src overview

### DIFF
--- a/backend/services/event-gateway/src/AGENT.md
+++ b/backend/services/event-gateway/src/AGENT.md
@@ -1,0 +1,14 @@
+# Event Gateway Source
+
+This directory hosts the transport plane's central event routing gateway.
+
+## Responsibilities
+- gRPC server listens on **port 50051**.
+- Terminates external TLS and maintains mutual TLS for internal services.
+- Validates **JWTs** issued by Keycloak.
+- Applies tenant isolation and rate limiting.
+- Routes validated requests to downstream processing services.
+- Enforces back-pressure by propagating gRPC flow control and limiting request sizes.
+
+## Architecture
+Part of the schema's **transport plane**, connecting capture clients to processing services.

--- a/backend/services/event-gateway/src/README.md
+++ b/backend/services/event-gateway/src/README.md
@@ -1,0 +1,19 @@
+# Event Gateway Source
+
+This folder contains the central event routing gateway.
+
+## Structure
+- **auth/**
+  - `jwt.rs`
+  - `keycloak.rs`
+  - `mod.rs`
+- **grpc/**
+  - `handlers.rs`
+  - `mod.rs`
+  - `server.rs`
+- **middleware/**
+  - `mod.rs`
+  - `rate_limit.rs`
+  - `tenant.rs`
+- `main.rs` — criticality: 10
+- `tls.rs` — criticality: 10


### PR DESCRIPTION
## Summary
- document event gateway src responsibilities and structure

## Testing
- `cargo test` (backend/services/event-gateway)


------
https://chatgpt.com/codex/tasks/task_e_68950725359c832a950a0a5f44ee962a