### PR TITLE
docs(desktop): add tauri backend docs

### DIFF
--- a/frontend/desktop/src-tauri/AGENT.md
+++ b/frontend/desktop/src-tauri/AGENT.md
@@ -1,0 +1,21 @@
+# Tauri Backend Agent
+
+This directory contains the Rust backend for the iVibe desktop client built with Tauri. As defined in the project's cross-platform client specification, the desktop app combines a Rust core with a TypeScript UI wrapped by Tauri and integrates activity watchers and the GraphQL API.
+
+## Responsibilities
+- **Window management**: create and manage application windows with `tauri::Window`, persist size and position, and handle multi-window scenarios.
+- **System tray integration**: register tray icon and menus, respond to events to show, hide, or quit the app.
+- **IPC bridge**: expose Rust commands via `invoke_handler` and emit events to the frontend for bidirectional communication.
+- **Native API access**: surface file system, notification, and OS-level features through Tauri commands.
+- **Auto-updater**: configure the Tauri updater in `tauri.conf.json`, including update endpoints and signature verification.
+- **Code signing**: enforce signing for release builds—Developer ID and notarisation on macOS, SignTool with timestamp on Windows, and optional GPG signatures on Linux.
+
+## Platform-specific build configurations
+- **Linux**: target AppImage and `.deb` bundles, specify icons in `icons/`.
+- **macOS**: set bundle identifier and signing identity; produce a signed `.app` and `.dmg`.
+- **Windows**: configure MSI installer options and code-signing certificate path.
+
+## Critical files
+- `Cargo.toml` – Rust crate manifest (criticality 9).
+- `tauri.conf.json` – Tauri configuration (criticality 10).
+

--- a/frontend/desktop/src-tauri/README.md
+++ b/frontend/desktop/src-tauri/README.md
@@ -1,0 +1,11 @@
+# Tauri Desktop Backend
+
+This directory hosts the backend for the iVibe desktop application built with Tauri.
+
+## Structure
+- `icons/` – application icons placeholder (`.gitkeep`).
+- `src/` – Rust source code (`main.rs`).
+- `Cargo.toml` – crate manifest (criticality 9).
+- `tauri.conf.json` – Tauri configuration (criticality 10).
+
+The frontend UI for the desktop app lives alongside this folder and communicates with this backend through Tauri's IPC bridge.


### PR DESCRIPTION
## Summary
- document Tauri backend responsibilities
- outline structure of src-tauri folder

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_689507f277c0832a8938d661e5508d90