### PR TITLE
docs: add browser extension source docs

### DIFF
--- a/frontend/browser-extension/src/AGENT.md
+++ b/frontend/browser-extension/src/AGENT.md
@@ -1,0 +1,20 @@
+# Browser Extension Source Guidelines
+
+This directory contains the Manifest V3 implementation of the iVibe browser extension. It streams browser activity to the local gateway and adheres to the platform's event schema for browser monitoring.
+
+## Architecture
+- **Manifest V3** service worker lives under `background/`.
+- **Background service worker** (`background/index.ts`) maintains a WebSocket to `ws://localhost:8081` for real-time streaming.
+- **Content scripts** in `content/` are injected into pages to capture DOM events, URLs and AI chat interactions.
+- **AI chat detection patterns** in `background/ai-detector.ts` and `content/classifier.ts` flag conversations and tag research context.
+- **Research classification**: content scripts annotate browsing sessions before events are emitted.
+- **Local WebSocket streaming**: events are sent to the gateway following the event schema (`event_id`, `user_id`, `timestamp`, `source='browser'`, `payload`).
+
+## File Overview
+- `background/` – service worker entry and trackers.
+- `content/` – injected scripts for page analysis and classification.
+- `options/` – extension configuration UI.
+- `popup/` – user-facing popup interface.
+- `utils/` – shared helpers for events and storage.
+
+Use TypeScript/React conventions, build with Vite, and keep the WebSocket connection open for live updates.

--- a/frontend/browser-extension/src/README.md
+++ b/frontend/browser-extension/src/README.md
@@ -1,0 +1,25 @@
+# Browser Extension Source
+
+This folder contains the browser extension implementation for iVibe. It is a Manifest V3 extension built with Vite and TypeScript.
+
+## Directory Structure
+- **background/**
+  - `ai-detector.ts`
+  - `index.ts`
+  - `tracker.ts`
+- **content/**
+  - `classifier.ts`
+  - `index.ts`
+  - `injector.ts`
+- **options/**
+  - `index.html`
+  - `options.tsx`
+- **popup/**
+  - `index.html`
+  - `popup.tsx`
+  - `styles.css`
+- **utils/**
+  - `events.ts`
+  - `storage.ts`
+
+Events recorded here are streamed via WebSocket to `ws://localhost:8081` using the platform's browser monitoring schema.


### PR DESCRIPTION
## Summary
- add AGENT guidelines describing Manifest V3 architecture, background worker, content scripts, AI detection, and WebSocket streaming
- document browser-extension source tree with README

## Testing
- `pnpm --filter browser-extension test` *(fails: fetch error installing pnpm)*
- `npm test` in `frontend/browser-extension` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689507e6f810832a9d767dd57992093d