### PR TITLE
docs: add AGENT and README for utils crate

### DIFF
--- a/backend/shared/utils/src/AGENT.md
+++ b/backend/shared/utils/src/AGENT.md
@@ -1,0 +1,25 @@
+# Utilities Guidance
+
+This directory contains shared utility modules for backend services.
+
+## Components
+- `crypto.rs` – implements AES-256-GCM authenticated encryption with keys derived using Argon2id.
+- `telemetry.rs` – configures tracing and OpenTelemetry, exporting Prometheus metrics on port 9090.
+- `lib.rs` – exposes utilities and centralises error handling helpers.
+
+## Security Best Practices
+- Follow repository security controls: run `cargo audit` and `cargo deny`, vendor dependencies, commit lockfiles, sign artifacts, enforce 2FA, and avoid install scripts.
+- Use 256-bit keys with unique 96-bit nonces. Zeroise secrets and avoid logging sensitive data.
+- Argon2id parameters should prioritise high memory cost to resist GPU attacks.
+
+## Telemetry & Metrics
+- Initialise tracing with OpenTelemetry. Propagate context across async boundaries.
+- Export metrics via the Prometheus endpoint on `0.0.0.0:9090`; restrict network access to trusted hosts.
+
+## Error Handling
+- Return `Result` types and map errors to the crate's unified error enum. Do not leak internal details in log messages.
+
+## Performance Considerations
+- Reuse cipher contexts and minimise allocations during encryption/decryption.
+- Keep telemetry instrumentation lightweight and bound metric label cardinality.
+- Avoid blocking operations in async contexts.

--- a/backend/shared/utils/src/README.md
+++ b/backend/shared/utils/src/README.md
@@ -1,0 +1,13 @@
+# Utilities Module
+
+Shared utility functions used across backend services.
+
+## Files
+
+| File | Description | Criticality |
+|------|-------------|-------------|
+| `crypto.rs` | Cryptographic helpers providing AES-256-GCM encryption with Argon2id key derivation. | 10 |
+| `lib.rs` | Module exports and error handling utilities. | 8 |
+| `telemetry.rs` | Tracing/OpenTelemetry setup with Prometheus metrics exporter on port 9090. | 8 |
+
+Criticality is rated on a 1-10 scale, with 10 representing the most sensitive code.


### PR DESCRIPTION
## Summary
- document encryption, telemetry, metrics and error-handling in utils
- add README listing crypto, telemetry, and lib modules with criticality

## Testing
- `cargo test -p utils`


------
https://chatgpt.com/codex/tasks/task_e_689507cb0214832aad5f4026f7e35533