### PR TITLE
docs(cli): document ivb src directory

### DIFF
--- a/backend/cli/src/AGENT.md
+++ b/backend/cli/src/AGENT.md
@@ -1,0 +1,10 @@
+# Agent Instructions
+
+- This directory houses the `ivb` CLI tool implementation.
+- Command parsing is handled by [`clap`](https://crates.io/crates/clap); extend commands within the `commands` module.
+- Configure the API client in `client.rs` to communicate with iVibe HTTPS endpoints.
+- Support event capture for headless sessions through capture-related commands.
+- Implement data export features for offline analysis.
+- Provide account management operations such as login and profile handling.
+- Read and write configuration values from `~/.ivibe/config.toml` via the `config` command.
+- Ensure all interactions respect the iVibe schema's CLI capabilities.

--- a/backend/cli/src/README.md
+++ b/backend/cli/src/README.md
@@ -1,0 +1,16 @@
+# ivb CLI Source
+
+This folder contains the implementation of the `ivb` command-line tool for the iVibe platform.
+
+## Structure
+
+- `commands/`
+  - `account.rs`
+  - `capture.rs`
+  - `config.rs`
+  - `export.rs`
+  - `mod.rs`
+- `client.rs` _(criticality: 9)_
+- `main.rs` _(criticality: 10)_
+
+Configuration is read from `~/.ivibe/config.toml`, and all API communication uses HTTPS endpoints.


### PR DESCRIPTION
## Summary
- add agent instructions for `ivb` CLI source folder
- document `src` layout and critical files

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689507b26a9c832aa930b754728c0d6d