### PR TITLE
docs: add public profile service guides

### DIFF
--- a/backend/services/public-profile-api/src/AGENT.md
+++ b/backend/services/public-profile-api/src/AGENT.md
@@ -1,0 +1,31 @@
+# Public Profile API – Source Agent
+
+- **Scope:** `backend/services/public-profile-api/src` directory.
+- **Purpose:** Serve public user profiles at `/u/{handle}` with privacy-respecting responses.
+
+## Guidelines
+- Use `handlers.rs` to route `/u/{handle}` requests.
+- Apply privacy bitmasks from `privacy::bitmask` before exposing metrics.
+- Render HTML via `templates/profile.html` for browser requests.
+- Provide JSON responses for API clients, exposing only fields allowed by privacy settings.
+- Cache profile payloads in Redis via `cache.rs` with sensible TTLs.
+- Issue PostgreSQL queries that filter on privacy flags, e.g.
+  ```sql
+  SELECT display_name, metrics
+  FROM public_profiles
+  WHERE handle = $1
+    AND (privacy_mask & $2) = $2;
+  ```
+- Reference the database schema's public profile service when adding or modifying queries.
+
+## Privacy and Metrics
+- Respect user-selected visibility; never expose metrics masked by privacy bits.
+- Only share selective metrics explicitly marked as public.
+
+## Templates
+- Keep `templates/profile.html` minimal and free of sensitive data.
+- Ensure all dynamic fields are escaped to prevent injection.
+
+## Caching
+- Cache HTML and JSON outputs separately.
+- Invalidate cache on profile updates or privacy changes.

--- a/backend/services/public-profile-api/src/README.md
+++ b/backend/services/public-profile-api/src/README.md
@@ -1,0 +1,15 @@
+# Public Profile API Source
+
+This folder implements the server-side logic for iVibe's public user profiles. Requests to `/u/{handle}` render a shareable page or return a JSON payload while respecting privacy preferences.
+
+## Layout
+- **privacy/**
+  - `bitmask.rs`
+  - `mod.rs`
+- **templates/**
+  - `profile.html`
+- `cache.rs` – Redis caching utilities *(criticality: 8)*
+- `handlers.rs` – `/u/{handle}` request handlers *(criticality: 9)*
+- `main.rs` – service entry point *(criticality: 10)*
+
+The service applies privacy bitmasks to user metrics, renders the `templates/profile.html` template for HTML responses, and exposes JSON endpoints for external integrations. Cached responses are stored in Redis to reduce database load.


### PR DESCRIPTION
## Summary
- document public profile source layout and responsibilities
- add agent instructions for privacy masking, caching, and `/u/{handle}` routing

## Testing
- `cargo test` in `backend/services/public-profile-api`


------
https://chatgpt.com/codex/tasks/task_e_68950780fc54832a8a0c40b25903711e