### PR TITLE
docs(storage): add agent and readme

### DIFF
--- a/backend/services/aw-server-rust/src/storage/AGENT.md
+++ b/backend/services/aw-server-rust/src/storage/AGENT.md
@@ -1,0 +1,30 @@
+# Storage Layer Guidance
+
+This directory defines the persistence interfaces for `aw-server-rust`. Implementations must align with the storage layer specifications under `/database/schemas`.
+
+## PostgreSQL
+- Batch insert events into the `events_raw` table using prepared statements or COPY operations.
+- Partition tables by month as specified in the schema.
+- Use a connection pool (e.g., `deadpool-postgres`) and apply retry logic for transient failures.
+- Expose Prometheus metrics for insert throughput and error rates.
+
+## Kafka
+- Produce messages to the `events_raw` topic.
+- Hash the `user_id` to choose the partition so a user's events remain ordered.
+- Reuse a pooled producer and retry sends with exponential backoff.
+- Monitor queue depth and publish success/failure metrics.
+
+## MinIO
+- PUT audio and screenshot objects into MinIO buckets.
+- Persist only object hashes and metadata in Postgres.
+- Pool connections, retry uploads, and log/metric failures.
+
+## Transaction Coordination
+- Coordinate Postgres writes, Kafka publishes, and MinIO uploads as a single logical transaction.
+- Use transactional outbox or compensating actions to maintain consistency.
+
+## Monitoring
+- Integrate with tracing and metrics frameworks for each backend.
+- Record latency, throughput, and error metrics.
+
+Refer to `/database/schemas` for detailed storage specifications.

--- a/backend/services/aw-server-rust/src/storage/README.md
+++ b/backend/services/aw-server-rust/src/storage/README.md
@@ -1,0 +1,11 @@
+# Storage Layer
+
+This module manages persistence for `aw-server-rust`.
+
+## Files
+- `postgres.rs` (criticality: 10) – PostgreSQL integration for `events_raw` batch inserts.
+- `kafka.rs` (criticality: 9) – Kafka producer for the `events_raw` topic using `user_id` hash partitioning.
+- `minio.rs` (criticality: 8) – MinIO client for audio and screenshot object storage.
+- `mod.rs` (criticality: 8) – Module glue and transaction coordination.
+
+Each backend should employ connection pooling, retry logic, and monitoring hooks. See `AGENT.md` for implementation guidance.


### PR DESCRIPTION
## Summary
- document storage module responsibilities and criticality
- outline backend expectations for Postgres, Kafka, MinIO, and transaction coordination

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895076855c8832a8fd3a4957a657fef