### PR TITLE
docs: add seed data guidelines

### DIFF
--- a/database/seeds/AGENT.md
+++ b/database/seeds/AGENT.md
@@ -1,0 +1,28 @@
+# Seed Data Guidelines
+
+This directory contains SQL scripts used for populating the database with deterministic data for development and automated tests.
+
+## Demo user creation
+- Provide demo accounts for each subscription tier (Free, Basic, Pro, Team, Business).
+- Use synthetic names and addresses; avoid real personally identifiable information.
+- Ensure fields conform to definitions in `database/schemas` to satisfy schema testing requirements.
+
+## Synthetic event generation
+- Generate representative events for different sources (terminal, browser, mobile, audio, emotion, vibe).
+- Include computed `vibe_score` values derived from stored emotion metrics.
+
+## Vibe score calculations
+- Calculate scores deterministically so tests can assert expected values.
+- Persist calculated scores in `test_events.sql` for downstream analytics tests.
+
+## Test data cleanup
+- After tests, remove demo data with `DELETE` statements targeting seeded records (e.g., emails prefixed with `demo_`).
+- Do not reuse seeded credentials outside automated testing environments.
+
+## Data privacy
+- All demo accounts must use fabricated information and are marked for deletion.
+- Never commit real user data or sensitive tokens in these seeds.
+
+## Testing reference
+- Run database migrations before applying seeds.
+- Seeds are consumed by schema tests to verify constraints, triggers, and vibe score calculations.

--- a/database/seeds/README.md
+++ b/database/seeds/README.md
@@ -1,0 +1,20 @@
+# Test Data Seeds
+
+This folder contains SQL scripts that populate the database with predictable data for tests and local development.
+
+## Files
+- **demo_users.sql** (criticality: 6) — inserts demo accounts across subscription tiers for authentication and billing tests.
+- **test_events.sql** (criticality: 6) — generates synthetic events with precomputed vibe scores for analytics validation.
+
+## Usage
+Apply these seeds only in testing environments after running all database migrations:
+
+```bash
+psql -f demo_users.sql
+psql -f test_events.sql
+```
+
+Seeded records are temporary. Clean them up using the deletion queries described in `AGENT.md` once tests complete.
+
+## Privacy
+All data is synthetic and for testing purposes only. Never use real user information or production credentials.


### PR DESCRIPTION
## Summary
- document seed SQL scripts with usage and privacy notes
- add guidance for generating demo users and events for tests

## Testing
- `cd backend/shared/models && cargo test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68950801baec832a97657ed02cc17948